### PR TITLE
Host the kids' 3C panel on GitHub Pages (free, for the iPhones)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: Deploy 3C panel to GitHub Pages
+
+# Publishes the offline kids' panel (public/3c.html) as a free static
+# site so it can be opened on the girls' iPhones and "Add to Home Screen".
+# The Cloudflare Worker (chat at /) is untouched; this only mirrors the
+# static panel to GitHub Pages.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Assemble site (panel is the landing page)
+        run: |
+          mkdir -p _site
+          cp public/3c.html _site/index.html
+          cp public/3c.html _site/3c.html
+          cp public/apple-touch-icon.png _site/apple-touch-icon.png
+      - uses: actions/configure-pages@v5
+        with:
+          enablement: true
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Adds a GitHub Actions workflow that publishes `public/3c.html` to **GitHub Pages** (free static hosting), so the panel can be opened on the daughters' iPhones and added to the Home Screen — no Cloudflare account needed.

- Serves the panel at the Pages root (`/`) and at `/3c.html`, plus the `apple-touch-icon`.
- Auto-enables Pages on first run (`actions/configure-pages` with `enablement: true`).
- The Cloudflare Worker (chat at `/`) is untouched; this only mirrors the static panel.

Once merged, the site will be live at `https://wofitnesscoltd-wq.github.io/wofitness-linechat/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k

---
_Generated by [Claude Code](https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k)_