### PR TITLE
Cross-device cloud sync via Cloudflare Durable Object

### DIFF
--- a/public/3c.html
+++ b/public/3c.html
@@ -597,6 +597,53 @@
     try { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); }
     catch (e) { alert("無法儲存資料，瀏覽器可能停用了本機儲存空間。"); }
     snapshot();
+    syncPush();
+  }
+
+  // ---------- 線上同步（Cloudflare Durable Object，從 Worker 開啟才會生效）----------
+  var SYNC_ROOM = "wofitmt";                 // 一家人共用同一個「房間」
+  var SYNC_URL = "/api/state?room=" + SYNC_ROOM;
+  var syncReady = false, syncWatermark = 0, syncPushTimer = null, syncTimer = null;
+  function applyCloudState(d) {
+    try {
+      state = fromData(d);
+      lastSig = null;
+      try { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); } catch (e) { }
+      fillSettings(); $("profileSel").value = state.profile; applyProfile();
+      render(); updateForm(); renderPet(); refreshLockSection(); applyLock();
+    } catch (e) { }
+  }
+  function syncPull(mode) {
+    fetch(SYNC_URL, { cache: "no-store" })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (rec) {
+        if (!rec) return;                    // 沒有 /api（例如直接用檔案或純 GitHub Pages）→ 不同步
+        syncReady = true;
+        if (rec.data && rec.updatedAt && rec.updatedAt > syncWatermark) {
+          if (sceneRunning) return;          // 動畫播放中先不打斷，下一輪再抓
+          syncWatermark = rec.updatedAt;
+          applyCloudState(rec.data);
+        } else if (mode === "seed" && (!rec.data || !rec.updatedAt)) {
+          syncPush(true);                    // 雲端是空的 → 把本機資料當起始上傳
+        }
+      })
+      .catch(function () { });
+  }
+  function syncPush(immediate) {
+    if (!syncReady) return;                  // 還沒抓過雲端前不上傳，避免蓋掉別台較新的資料
+    clearTimeout(syncPushTimer);
+    syncPushTimer = setTimeout(function () {
+      fetch(SYNC_URL, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ data: state }) })
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (res) { if (res && res.updatedAt) syncWatermark = res.updatedAt; })
+        .catch(function () { });
+    }, immediate ? 60 : 1500);
+  }
+  function startSync() {
+    syncPull("seed");
+    syncTimer = setInterval(function () { syncPull(); }, 15000);
+    window.addEventListener("focus", function () { syncPull(); });
+    document.addEventListener("visibilitychange", function () { if (!document.hidden) syncPull(); });
   }
   function loadHistory() { try { var r = localStorage.getItem(HISTORY_KEY); var a = r ? JSON.parse(r) : []; return Array.isArray(a) ? a : []; } catch (e) { return []; } }
   function saveHistory(h) { try { localStorage.setItem(HISTORY_KEY, JSON.stringify(h)); } catch (e) { } }
@@ -1419,7 +1466,7 @@
       return '<div class="uitem"><div><span class="tag ' + ch.cls + '">' + ch.emoji + " " + ch.name + '</span> <b>−' + u.minutes + ' 分</b>' + (u.note ? ' <span class="meta">· ' + escapeHtml(u.note) + "</span>" : "") + '<div class="meta">' + fmtDate(u.date) + '</div></div><button class="btn ghost" data-uden="' + u.id + '">刪除</button></div>';
     }).join("");
   }
-  function isWide() { return !!(window.matchMedia && window.matchMedia("(min-width:1500px)").matches); }
+  function isWide() { return !!(window.matchMedia && window.matchMedia("(min-width:1024px)").matches); }
   function render() { renderRules(); renderMonth(); renderCards(); renderPending(); renderRecords(); renderUsages(); if (isWide()) renderPet(); }
 
   // ================= render: 寵物 =================
@@ -1794,7 +1841,8 @@
   applyProfile();
   fillSettings(); updateForm(); render(); showTab("sleep");
   refreshLockSection(); applyLock(); renderHistory();
-  if (window.matchMedia) { try { window.matchMedia("(min-width:1500px)").addEventListener("change", function () { render(); }); } catch (e) {} }
+  if (window.matchMedia) { try { window.matchMedia("(min-width:1024px)").addEventListener("change", function () { render(); }); } catch (e) {} }
+  startSync();
 })();
 </script>
 </body>

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,13 @@ export default {
       return env.ASSETS.fetch(request);
     }
 
+    // Cross-device sync for the Mia & Tia 3C panel (stored in a Durable Object).
+    if (url.pathname === "/api/state") {
+      const room = url.searchParams.get("room") || "default";
+      const id = env.SYNC.idFromName(room);
+      return env.SYNC.get(id).fetch(request);
+    }
+
     // API Routes
     if (url.pathname === "/api/chat") {
       // Handle POST requests for chat
@@ -96,4 +103,64 @@ async function handleChatRequest(
       },
     );
   }
+}
+
+/**
+ * Durable Object that stores one shared copy of the 3C panel state so that a
+ * family's devices (iPhone / iPad / computer) all see and edit the same data.
+ * Storage is SQLite-backed (available on the Workers free plan) via the
+ * built-in key/value storage API. Last write wins.
+ */
+const CORS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, PUT, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+  "Cache-Control": "no-store",
+};
+
+export class SyncRoom {
+  private storage: DurableObjectStorage;
+
+  constructor(state: DurableObjectState, _env: Env) {
+    this.storage = state.storage;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { headers: CORS });
+    }
+
+    if (request.method === "GET") {
+      const rec =
+        (await this.storage.get<unknown>("rec")) ||
+        { rev: 0, updatedAt: 0, data: null };
+      return jsonResponse(rec);
+    }
+
+    if (request.method === "PUT") {
+      let body: { data?: unknown } = {};
+      try {
+        body = (await request.json()) as { data?: unknown };
+      } catch {
+        /* ignore malformed body */
+      }
+      const cur =
+        ((await this.storage.get<{ rev?: number }>("rec")) || { rev: 0 });
+      const rec = {
+        rev: (cur.rev || 0) + 1,
+        updatedAt: Date.now(),
+        data: body && body.data,
+      };
+      await this.storage.put("rec", rec);
+      return jsonResponse({ ok: true, rev: rec.rev, updatedAt: rec.updatedAt });
+    }
+
+    return new Response("Method not allowed", { status: 405, headers: CORS });
+  }
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    headers: { ...CORS, "Content-Type": "application/json" },
+  });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,11 @@ export interface Env {
    * Binding for static assets.
    */
   ASSETS: { fetch: (request: Request) => Promise<Response> };
+
+  /**
+   * Durable Object used to sync the Mia & Tia 3C panel across devices.
+   */
+  SYNC: DurableObjectNamespace;
 }
 
 /**

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,5 +17,9 @@
   "ai": {
     "binding": "AI"
   },
+  "durable_objects": {
+    "bindings": [{ "name": "SYNC", "class_name": "SyncRoom" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["SyncRoom"] }],
   "upload_source_maps": true
 }


### PR DESCRIPTION
Adds cross-device sync so the family's iPhone, iPad and computer all see and edit the same panel data.

- **Worker**: new `/api/state` endpoint backed by a **SQLite-backed Durable Object** (`SyncRoom`) — no extra account/database to provision; it's created on deploy. Existing chat (`/api/chat`) and asset serving untouched.
- **Panel**: pulls cloud state on open/focus and every 15s; pushes (debounced) on every change; pulls before pushing so it won't clobber newer data; silently no-ops where `/api/state` isn't reachable.

This is to confirm the repo's Cloudflare build picks it up. Once deployed, opening the panel from the **Worker URL** (`/3c.html`) syncs automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k)_