### PR TITLE
Name the kids' panel Worker mia-tia-3c

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,7 +3,7 @@
  * https://developers.cloudflare.com/workers/wrangler/configuration/
  */ {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "wofitness-linechat",
+  "name": "mia-tia-3c",
   "main": "src/index.ts",
   "compatibility_date": "2025-04-01",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],


### PR DESCRIPTION
Renames the Worker to `mia-tia-3c` so the kids' 3C panel + sync deploys as its own clearly-named Worker, never confused with the customer-service Worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k)_