### PR TITLE
真實生活：寵物會自己變化＋連鎖互動＋拿掉等級文字

### DIFF
--- a/public/3c.html
+++ b/public/3c.html
@@ -519,7 +519,7 @@
 (function () {
   "use strict";
 
-  var APP_VER = "v1.4 · 真實連鎖互動 · 2026-06-20";
+  var APP_VER = "v1.5 · 真實生活版 · 2026-06-20";
   var STORAGE_KEY = "mt-3c-panel-v1";
   var HISTORY_KEY = "mt-3c-history-v1";
   var HISTORY_MAX = 30;
@@ -565,12 +565,12 @@
   var SPECIES_IDS = ["bunny", "cat", "bear", "puppy", "fox", "panda", "dino", "unicorn"];
   var STAGE_NAME = ["幼年", "小童", "少年", "成年"];
   var NEEDS = [
-    { key: "hunger", name: "肚子", emoji: "🍎", low: "肚子餓", rate: 5 },
-    { key: "thirst", name: "喝水", emoji: "💧", low: "口渴", rate: 6 },
-    { key: "energy", name: "精神", emoji: "⚡", low: "好累", rate: 4 },
-    { key: "clean", name: "清潔", emoji: "🫧", low: "好髒", rate: 3 },
-    { key: "bladder", name: "如廁", emoji: "🚽", low: "想上廁所", rate: 7 },
-    { key: "happy", name: "心情", emoji: "💛", low: "想討抱", rate: 4 }
+    { key: "hunger", name: "肚子", emoji: "🍎", low: "肚子餓", rate: 10 },
+    { key: "thirst", name: "喝水", emoji: "💧", low: "口渴", rate: 12 },
+    { key: "energy", name: "精神", emoji: "⚡", low: "好累", rate: 8 },
+    { key: "clean", name: "清潔", emoji: "🫧", low: "好髒", rate: 7 },
+    { key: "bladder", name: "如廁", emoji: "🚽", low: "想上廁所", rate: 14 },
+    { key: "happy", name: "心情", emoji: "💛", low: "想討抱", rate: 8 }
   ];
   var NEED_MAP = {}; NEEDS.forEach(function (n) { NEED_MAP[n.key] = n; });
   // 需求嚴重等級：0 健康 ／ 1 輕 ／ 2 中 ／ 3 急（越低越嚴重）
@@ -1324,7 +1324,8 @@
   function tickPet(p) {
     var now = Date.now(), last = p.lastTick || now, hrs = (now - last) / 3600000; p.lastTick = now;
     if (hrs <= 0) return;
-    NEEDS.forEach(function (n) { var v = (p.needs[n.key] == null) ? 80 : p.needs[n.key]; p.needs[n.key] = Math.max(8, Math.round(v - n.rate * hrs)); });
+    // 不取整，零頭也會累積，這樣即使每幾秒 tick 一次也會慢慢下降（顯示時才四捨五入）
+    NEEDS.forEach(function (n) { var v = (p.needs[n.key] == null) ? 80 : p.needs[n.key]; p.needs[n.key] = Math.max(8, v - n.rate * hrs); });
   }
   var petExpr = "auto", exprTimer = null, petFlash = null;
   var GROWTH_PER_CARE = 2, DAILY_GROWTH_CAP = 12, NEED_LOW = 90;
@@ -1747,6 +1748,17 @@
       '<section class="block"><div class="wallet ' + (bal < 0 ? "neg" : "") + '">👛 ' + ch.name + " 的 3C 存摺：<b>" + walletStr + "</b></div>" +
         '<h2 style="margin-top:12px">🛍️ 換裝小舖</h2>' + slotTabs + wardrobeHTML(petWho, petSlot) +
         '<p class="hint">到「🐾夥伴」可以領養新朋友（每一隻都要從小養大、分開計算）；基本款免費，有標價的用 3C 點數換；🔒限定款要連續睡飽才解鎖，或用 3C 換。</p></section>';
+    liveSig = petLiveSig(p);
+  }
+  // 寵物會「自己」隨時間變化：每隔一段時間就讓需求下降，狀態有變才重畫畫面
+  function petLiveSig(p) { var s = ""; for (var i = 0; i < NEEDS.length; i++) s += needTier(p.needs[NEEDS[i].key] == null ? 80 : p.needs[NEEDS[i].key]); return s + (petThriving(p) ? "T" : ""); }
+  var liveSig = null;
+  function liveTick(force) {
+    if (sceneRunning) return;
+    ["mia", "tia", "self"].forEach(function (c) { var r = state.pets[c].roster; Object.keys(r).forEach(function (sp) { tickPet(r[sp]); }); });
+    if (!$("view-pet") || $("view-pet").style.display === "none" || petExpr !== "auto") { liveSig = null; return; }
+    var sig = petLiveSig(activePet(petWho));
+    if (force || sig !== liveSig) { liveSig = sig; renderPet(); }
   }
   function renamePet() {
     var p = activePet(petWho);
@@ -2107,6 +2119,9 @@
   if (window.matchMedia) { try { window.matchMedia("(min-width:1024px)").addEventListener("change", function () { render(); }); } catch (e) {} }
   startSync();
   renderStateGallery();
+  setInterval(liveTick, 12000);
+  document.addEventListener("visibilitychange", function () { if (!document.hidden) liveTick(true); });
+  window.addEventListener("focus", function () { liveTick(true); });
 })();
 </script>
 </body>

--- a/public/3c.html
+++ b/public/3c.html
@@ -519,7 +519,7 @@
 (function () {
   "use strict";
 
-  var APP_VER = "v1.3 · 互動生動版 · 2026-06-20";
+  var APP_VER = "v1.4 · 真實連鎖互動 · 2026-06-20";
   var STORAGE_KEY = "mt-3c-panel-v1";
   var HISTORY_KEY = "mt-3c-history-v1";
   var HISTORY_MAX = 30;
@@ -576,7 +576,6 @@
   // 需求嚴重等級：0 健康 ／ 1 輕 ／ 2 中 ／ 3 急（越低越嚴重）
   // 掉到剩約 2/3（<67）就開始有表情；剩一半（50）已是「中」，1/4 以下是「急」
   function needTier(v) { return v >= 67 ? 0 : v >= 50 ? 1 : v >= 28 ? 2 : 3; }
-  var TIER_TAG = ["", "·輕", "·中", "·急"];
   function defaultPet() {
     return { name: "", color: "theme",
       wear: { hat: null, eyes: null, outfit: null, back: null, hand: null, bg: null, fx: null },
@@ -1311,14 +1310,15 @@
   }
 
   // ---------- pet care ----------
+  // side：真實連鎖反應（照顧完會牽動其他需求，模擬生理現實）；note：完成後的小提示
   var ACTIONS = {
-    feed: { emoji: "🍎", label: "餵食", need: "hunger", fx: "feed", parts: ["🍎", "😋", "✨"], n: 5 },
-    drink: { emoji: "🥤", label: "喝水", need: "thirst", fx: "drink", parts: ["💧", "💧", "😋"], n: 6 },
-    bath: { emoji: "🛁", label: "洗澡", need: "clean", fx: "bath", parts: ["🫧", "🫧", "✨", "💧"], n: 9 },
-    toilet: { emoji: "🚽", label: "如廁", need: "bladder", fx: "toilet", parts: ["💨", "😌", "✨"], n: 4 },
-    play: { emoji: "🎈", label: "玩耍", need: "happy", fx: "play", parts: ["🎈", "⭐", "🎉", "😆"], n: 7 },
-    sleep: { emoji: "😴", label: "哄睡", need: "energy", fx: "sleep", parts: ["💤", "💤", "✨"], n: 5 },
-    pat: { emoji: "🫶", label: "摸摸", need: "happy", fx: "pat", parts: ["❤️", "💕", "✨"], n: 6 }
+    feed: { emoji: "🍎", label: "餵食", need: "hunger", fx: "feed", parts: ["🍎", "😋", "✨"], n: 5, side: { bladder: -7, clean: -3, happy: 4 }, note: "吃飽飽～等一下可能會想上廁所 🚽" },
+    drink: { emoji: "🥤", label: "喝水", need: "thirst", fx: "drink", parts: ["💧", "💧", "😋"], n: 6, side: { bladder: -10, happy: 3 }, note: "水分補足～記得帶牠去尿尿 💧" },
+    bath: { emoji: "🛁", label: "洗澡", need: "clean", fx: "bath", parts: ["🫧", "🫧", "✨", "💧"], n: 9, side: { energy: -16, happy: 8 }, note: "洗香香～暖呼呼的有點想睡了 😴" },
+    toilet: { emoji: "🚽", label: "如廁", need: "bladder", fx: "toilet", parts: ["💨", "😌", "✨"], n: 4, side: { clean: -7, happy: 3 }, note: "上完廁所～手手要洗乾淨喔 🧼" },
+    play: { emoji: "🎈", label: "玩耍", need: "happy", fx: "play", parts: ["🎈", "⭐", "🎉", "😆"], n: 7, side: { clean: -16, hunger: -12, thirst: -12, energy: -10 }, note: "玩得超開心！但流汗弄髒了，肚子也餓、口也渴了 💦" },
+    sleep: { emoji: "😴", label: "哄睡", need: "energy", fx: "sleep", parts: ["💤", "💤", "✨"], n: 5, side: { hunger: -10, bladder: -12, thirst: -5, happy: 5 }, note: "睡飽飽～醒來肚子餓、也想尿尿 🌅" },
+    pat: { emoji: "🫶", label: "摸摸", need: "happy", fx: "pat", parts: ["❤️", "💕", "✨"], n: 6, note: "秀秀～心情變好了 💕" }
   };
   var ACTION_ORDER = ["feed", "drink", "bath", "toilet", "play", "sleep", "pat"];
   function tickPet(p) {
@@ -1521,7 +1521,8 @@
     var a = ACTIONS[key], p = activePet(childKey), before = sceneBefore;
     p.needs[a.need] = 100;
     if (key === "sleep") p.needs.energy = 100;
-    if (key !== "pat" && key !== "play") p.needs.happy = Math.min(100, (p.needs.happy || 80) + 6);
+    // 真實連鎖反應：玩完會髒會餓會渴、洗完澡想睡、吃喝完想上廁所…
+    if (a.side) Object.keys(a.side).forEach(function (k) { p.needs[k] = Math.max(8, Math.min(100, (p.needs[k] == null ? 80 : p.needs[k]) + a.side[k])); });
     petFlash = null;
     if (before < NEED_LOW) {
       var day = todayStr();
@@ -1532,7 +1533,8 @@
         p.growth = Math.min(160, (p.growth || 0) + add); p.growthToday = (p.growthToday || 0) + add;
         if (petStage(p.growth) > was) petFlash = { cls: "grow", text: "🎉 長大了！變成「" + STAGE_NAME[petStage(p.growth)] + "」囉！" };
       } else petFlash = { cls: "info", text: "今天已經長大很多囉，明天再來陪它 🌙" };
-    } else petFlash = { cls: "info", text: "它現在不太需要～不過心情更好了 😊" };
+    }
+    if (!petFlash) petFlash = { cls: "info", text: a.note || "它現在心情更好了 😊" };
     save();
     petExpr = "happy"; renderPet();
     var stage2 = document.querySelector(".petstage");
@@ -1638,14 +1640,14 @@
   function needsHTML(p) {
     return '<div class="stats">' + NEEDS.map(function (n) {
       var v = Math.round(p.needs[n.key] == null ? 80 : p.needs[n.key]); var lv = needTier(v);
-      var tag = lv ? ' <b class="ntag t' + lv + '">' + n.low + TIER_TAG[lv] + "</b>" : "";
+      var tag = lv ? ' <b class="ntag t' + lv + '">' + n.low + "</b>" : "";
       return '<div class="stat"><span class="sl">' + n.emoji + " " + n.name + tag + '</span><div class="bar"><i class="bl' + lv + '" style="width:' + v + '%"></i></div></div>';
     }).join("") + "</div>";
   }
   function petStatusLine(p) {
     var lows = lowNeeds(p);
     if (!lows.length) return '<div class="petstatus ok">😊 心情很好，跟你玩得開心～</div>';
-    return '<div class="petstatus need' + (lows[0].lv >= 3 ? " urgent" : "") + '">💬 ' + lows.map(function (n) { return NEED_MAP[n.key].low + TIER_TAG[n.lv]; }).join("、") + "！</div>";
+    return '<div class="petstatus need' + (lows[0].lv >= 3 ? " urgent" : "") + '">💬 ' + lows.map(function (n) { return NEED_MAP[n.key].low; }).join("、") + "！</div>";
   }
   function petAgeHTML(p) {
     var g = p.growth || 0, st = petStage(g), nx = nextStageAt(g), prev = [0, 15, 40, 80][st];
@@ -1724,7 +1726,7 @@
     var moodNow = (petExpr === "auto") ? petMood(p) : null;
     var artCls = (moodNow && moodNow.lv >= 3) ? " distress" : "";
     var bubble = "";
-    if (moodNow) { var nbb = NEED_MAP[moodNow.key]; bubble = '<div class="moodbubble t' + moodNow.lv + '">' + nbb.emoji + " " + nbb.low + TIER_TAG[moodNow.lv] + "！</div>"; }
+    if (moodNow) { var nbb = NEED_MAP[moodNow.key]; bubble = '<div class="moodbubble t' + moodNow.lv + '">' + nbb.emoji + " " + nbb.low + "！</div>"; }
     else if (petExpr === "auto" && petThriving(p)) bubble = '<div class="moodbubble happy">🥰 好幸福～</div>';
     $("view-pet").innerHTML =
       swRow +
@@ -2068,19 +2070,19 @@
     var host = document.getElementById("stategallery");
     if (location.hash !== "#states") { if (host) host.style.display = "none"; return; }
     if (!host) { host = document.createElement("div"); host.id = "stategallery"; document.body.appendChild(host); }
-    var TIERS = [["輕", 58], ["中", 38], ["急", 14]];
+    var TIERS = [58, 38, 14];
     var h = '<div class="gwrap"><button class="gclose">✕ 關閉</button>' +
-      "<h1>🎭 寵物狀態圖鑑</h1><p class=\"ghint\">目前版本：" + APP_VER + "。掉到剩約 2/3 就開始有表情；同一隻兔兔，肚子餓／口渴／想睡／髒了／想尿尿／寂寞時會有不同表情，越嚴重（輕→中→急）臉和身上的變化越明顯。</p>";
-    h += '<div class="ggrid">' + galleryCard("😊 健康", "全部充足", null) + "</div>";
+      "<h1>🎭 寵物狀態圖鑑</h1><p class=\"ghint\">目前版本：" + APP_VER + "。掉到剩約 2/3 就開始有表情；同一隻兔兔，肚子餓／口渴／想睡／髒了／想尿尿／寂寞時會有不同表情，越低變化越明顯。</p>";
+    h += '<div class="ggrid">' + galleryCard("😊 健康", "", null) + "</div>";
     NEEDS.forEach(function (n) {
       h += "<h3>" + n.emoji + " " + n.name + "（" + n.low + "）</h3><div class=\"ggrid\">";
-      TIERS.forEach(function (t) { var nd = {}; nd[n.key] = t[1]; h += galleryCard(t[0] + "（" + t[1] + "%）", "單一狀態", nd); });
+      TIERS.forEach(function (v) { var nd = {}; nd[n.key] = v; h += galleryCard("剩 " + v + "%", "", nd); });
       h += "</div>";
     });
     h += '<h2>👯 複數狀態（同時好幾項）</h2><div class="ggrid">';
-    h += galleryCard("肚子餓＋好髒", "中＋急", { hunger: 38, clean: 14 });
-    h += galleryCard("口渴＋想尿＋寂寞", "三項同時", { thirst: 40, bladder: 30, happy: 58 });
-    h += galleryCard("全部都很急", "崩潰邊緣", { hunger: 12, thirst: 12, energy: 12, clean: 12, bladder: 12, happy: 12 });
+    h += galleryCard("肚子餓＋好髒", "", { hunger: 38, clean: 14 });
+    h += galleryCard("口渴＋想尿＋寂寞", "", { thirst: 40, bladder: 30, happy: 58 });
+    h += galleryCard("全部都很低", "", { hunger: 12, thirst: 12, energy: 12, clean: 12, bladder: 12, happy: 12 });
     h += '</div><h2>✨ 特別狀態</h2><div class="ggrid">';
     h += galleryCard("🥰 幸福", "照顧滿分", { hunger: 95, thirst: 95, energy: 95, clean: 95, bladder: 95, happy: 95 });
     h += galleryCard("🤒 生病", "太久沒顧", { hunger: 10, thirst: 10, clean: 10 });


### PR DESCRIPTION
## 為什麼改（家長三點回饋）

1. 不要「肚子餓·輕」這種等級文字。
2. 照顧動作要有生理／現實的連鎖反應（洗完澡想睡、運動完會髒…）。
3. **寵物狀態要會自己變**，不然沒辦法實際照顧、得到真實體驗。

只動 `public/3c.html`。

## 改了什麼

**A. 寵物會「自己」隨時間變化（修一個關鍵 bug）**
- 修正：`tickPet` 原本每次都四捨五入，頻繁更新時零頭被吃掉 → 需求幾乎不下降、卡在全滿。改成**累積小數**，顯示時才取整。
- 衰減速度調快約 2 倍：不再卡滿，約 **2–3 小時**就會開始想討照顧，整天有起伏。
- **即時心跳**：每 12 秒、以及切回 App／視窗重新聚焦時，需求持續下降；狀態有變才重畫，不用手動重新整理。

**B. 照顧動作的真實連鎖反應**（完成後跳一句提示說明因果）
| 動作 | 主要 | 連鎖副作用 |
|---|---|---|
| 🛁 洗澡 | 清潔↑ | 暖呼呼**想睡**、心情↑ |
| 🎈 玩耍/運動 | **心情↑（目的）** | 流汗**變髒**、餓、渴、累 |
| 🍎 餵食 | 肚子↑ | 等等**想上廁所** |
| 🥤 喝水 | 喝水↑ | **想尿尿** |
| 🚽 如廁 | 如廁↑ | 要**洗手** |
| 😴 哄睡 | 精神↑ | 醒來**餓＋想尿** |

**C. 拿掉等級文字註記**
- 泡泡／狀態列／需求條不再出現「·輕／·中／·急」；嚴重度仍靠表情、條色、!／!! 呈現。`#states` 圖鑑改用「剩 X%」。

- 版本 `v1.5 · 真實生活版`。

## 驗證

- `node --check` 通過；無殘留等級文字。
- VM＋DOM stub 載入真實程式，初始化無錯誤；版本字串正確。
- 模擬頻繁 tick（每 12 秒，共 30 分）：肚 80→75、廁 80→73 → **衰減確實會累積（bug 已修）**；放 3 小時 → 肚 50(輕)、水 44(中)、廁 38(中)，照顧節奏合理。
- 模擬各動作 finishScene 連鎖：洗完澡精神→64（會想睡 ✓）、玩完清潔→64（會髒 ✓）且心情=100 ✓。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k