### PR TITLE
修正：雲端同步把寵物即時需求洗掉，造成狀態忽高忽低

### DIFF
--- a/public/3c.html
+++ b/public/3c.html
@@ -519,7 +519,7 @@
 (function () {
   "use strict";
 
-  var APP_VER = "v1.6 · 沉浸場景版 · 2026-06-20";
+  var APP_VER = "v1.7 · 同步穩定版 · 2026-06-20";
   var STORAGE_KEY = "mt-3c-panel-v1";
   var HISTORY_KEY = "mt-3c-history-v1";
   var HISTORY_MAX = 30;
@@ -663,11 +663,40 @@
   function cloudShared(st) {
     return { settings: st.settings, records: st.records, usages: st.usages, pets: st.pets, inventory: st.inventory };
   }
+  // 寵物的「即時狀態」（需求值、計時、今日故事）屬於各裝置自己、依時間即時演算，
+  // 不該被雲端拉下來的版本覆蓋，否則會和本機的即時衰減打架、畫面忽高忽低。
+  // → 同步時只接受雲端的「持久資料」（成長、外觀、名字、roster、庫存），需求保留本機的。
+  function capturePetLive(st) {
+    var m = {};
+    ["mia", "tia", "self"].forEach(function (c) {
+      var cp = st.pets && st.pets[c]; if (!cp || !cp.roster) return;
+      m[c] = {};
+      Object.keys(cp.roster).forEach(function (sp) {
+        var p = cp.roster[sp] || {};
+        m[c][sp] = { needs: p.needs, lastTick: p.lastTick, storyDay: p.storyDay, storyIdx: p.storyIdx };
+      });
+    });
+    return m;
+  }
+  function restorePetLive(st, m) {
+    if (!m) return;
+    ["mia", "tia", "self"].forEach(function (c) {
+      if (!m[c] || !st.pets[c] || !st.pets[c].roster) return;
+      Object.keys(st.pets[c].roster).forEach(function (sp) {
+        var saved = m[c][sp]; if (!saved || !saved.needs) return;
+        var p = st.pets[c].roster[sp];
+        p.needs = saved.needs; p.lastTick = saved.lastTick;
+        p.storyDay = saved.storyDay; p.storyIdx = saved.storyIdx;
+      });
+    });
+  }
   function applyCloudState(d) {
     try {
       var keepProfile = state.profile, keepLock = state.lock;   // 保留本機的「專屬機 / 家長鎖」設定
+      var keepLive = capturePetLive(state);                     // 保留本機寵物的即時需求/計時
       state = fromData(d);
       state.profile = keepProfile; state.lock = keepLock;
+      restorePetLive(state, keepLive);
       lastSig = null;
       try { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); } catch (e) { }
       fillSettings(); $("profileSel").value = state.profile; applyProfile();


### PR DESCRIPTION
## 症狀（家長回報）

打開自己的測試版（速隨），寵物需求本來只有其中一項偏低，**突然全部掉到快見底、又跳回只有一項，反覆閃動**，狀態不穩。

## 原因

是 v1.5 加入「即時衰減」後與雲端同步打架的 race：

1. 即時衰減在記憶體裡演算（每 12 秒推進 `lastTick`，但不存檔）。
2. 雲端 `syncPull` 會用 `applyCloudState` **整包覆蓋** `state`——包含寵物 `needs` 和一個**較舊的 `lastTick`**。
3. 剛拉下來時畫面顯示雲端的舊需求（「只有一項低」）；**下一次即時 tick 又用那個舊 `lastTick` 一次補算超大時間差 → 全部需求瞬間見底**；再被下一輪拉取覆蓋回去 →「忽高忽低」。

## 修正

寵物的**即時狀態**（`needs` / `lastTick` / 今日故事）本質上屬於各裝置自己、依時間即時演算，不該被雲端版本覆蓋。

- 新增 `capturePetLive()` / `restorePetLive()`：`applyCloudState` 時**保留本機的即時需求與計時**，只接受雲端的**持久資料**（成長、外觀、名字、roster、庫存）。
- 版本 `v1.7 · 同步穩定版`。

## 驗證

- `node --check` 通過。
- VM 模擬同步合併：本機「只有口渴偏低（thirst 40）」、雲端為「全部 8＋極舊 lastTick＋成長/顏色不同」。合併後：
  - needs 維持本機 `{hunger:78, thirst:40, …}`，**沒有被洗成全部 8** ✓
  - `lastTick` 保留本機（不會再用舊值補算暴衝）✓
  - 成長(34)、顏色(rainbow) 等持久資料正確採用雲端 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k

---
_Generated by [Claude Code](https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k)_