### PR TITLE
主動 debug：修掉互動中殘留泡泡＋等級判定一致性

### DIFF
--- a/public/3c.html
+++ b/public/3c.html
@@ -205,6 +205,7 @@
   .moodbubble.t2 { border-color: #ff9a3d; color: #a8410a; }
   .moodbubble.t3 { border-color: var(--bad); color: var(--bad); }
   .moodbubble.happy { border-color: #ff8fc2; color: #d84f8f; }
+  .scene-on .moodbubble { display: none; }   /* 互動播放中不顯示需求泡泡 */
   @keyframes bubblepop { 0% { transform: translateX(-50%) scale(.5); opacity: 0; } 60% { transform: translateX(-50%) scale(1.06); } 100% { transform: translateX(-50%) scale(1); opacity: 1; } }
   .carebtns.busy { opacity: .3; pointer-events: none; }
   #view-pet > .petstage { position: sticky; top: 6px; z-index: 30; }
@@ -519,7 +520,7 @@
 (function () {
   "use strict";
 
-  var APP_VER = "v1.7 · 同步穩定版 · 2026-06-20";
+  var APP_VER = "v1.8 · 微調修正版 · 2026-06-20";
   var STORAGE_KEY = "mt-3c-panel-v1";
   var HISTORY_KEY = "mt-3c-history-v1";
   var HISTORY_MAX = 30;
@@ -1153,7 +1154,7 @@
   // 所有偏低的需求，依嚴重程度排序（最急的在前）→ 可同時呈現複數狀態，並各自帶嚴重等級 lv
   function lowNeeds(p) {
     var arr = [];
-    for (var i = 0; i < NEEDS.length; i++) { var k = NEEDS[i].key, v = (p.needs[k] == null) ? 80 : p.needs[k]; if (v < 67) arr.push({ key: k, v: v, lv: needTier(v) }); }
+    for (var i = 0; i < NEEDS.length; i++) { var k = NEEDS[i].key, v = Math.round((p.needs[k] == null) ? 80 : p.needs[k]); if (v < 67) arr.push({ key: k, v: v, lv: needTier(v) }); }
     arr.sort(function (a, b) { return a.v - b.v; });
     return arr;
   }
@@ -1753,7 +1754,7 @@
   var ACT_COLOR = { feed: "#ff8a3d", drink: "#3db4ef", bath: "#46c7e0", toilet: "#9b8cff", play: "#ff6fae", sleep: "#7c6cff", pat: "#ff5f8f" };
   function careRound(p) {
     return '<div class="carebtns">' + ACTION_ORDER.map(function (k) {
-      var a = ACTIONS[k], v = (p.needs[a.need] == null) ? 80 : p.needs[a.need], lv = needTier(v);
+      var a = ACTIONS[k], v = Math.round((p.needs[a.need] == null) ? 80 : p.needs[a.need]), lv = needTier(v);
       return '<button class="carebtn" data-act="' + k + '" style="--c:' + ACT_COLOR[k] + '" aria-label="' + a.label + '" title="' + a.label + '">' +
         a.emoji + (lv ? '<span class="urgent l' + lv + '">' + (lv >= 3 ? "!!" : "!") + "</span>" : "") + '<span class="cl">' + a.label + "</span></button>";
     }).join("") + "</div>";
@@ -1796,7 +1797,7 @@
     liveSig = petLiveSig(p);
   }
   // 寵物會「自己」隨時間變化：每隔一段時間就讓需求下降，狀態有變才重畫畫面
-  function petLiveSig(p) { var s = ""; for (var i = 0; i < NEEDS.length; i++) s += needTier(p.needs[NEEDS[i].key] == null ? 80 : p.needs[NEEDS[i].key]); return s + (petThriving(p) ? "T" : ""); }
+  function petLiveSig(p) { var s = ""; for (var i = 0; i < NEEDS.length; i++) s += needTier(Math.round(p.needs[NEEDS[i].key] == null ? 80 : p.needs[NEEDS[i].key])); return s + (petThriving(p) ? "T" : ""); }
   var liveSig = null;
   function liveTick(force) {
     if (sceneRunning) return;


### PR DESCRIPTION
## 主動 debug 結果

家長請我主動找 bug。我對最近改動（即時衰減、連鎖互動、整片場景、同步修正）做了一輪稽核＋全面 smoke 測試，找到並修正 2 個問題；另確認多項不是 bug。

### 修正 1（視覺）：互動播放中殘留的需求泡泡
`runScene` 開始照顧互動時，沒有移除前一刻的需求泡泡（如「💧 口渴！」），也沒有 CSS 隱藏它 → 泡泡會浮在新切換的廁所／浴室場景上。
→ 加 `.scene-on .moodbubble { display: none; }`。

### 修正 2（一致性）：等級判定的四捨五入不一致
需求條（`needsHTML`）用**四捨五入後**的值決定等級，但 `lowNeeds`／`careRound`／`petLiveSig` 用**原始小數**。邊界值（如 66.6）會出現「條顯示 67% 看似健康，但泡泡／照顧鈕卻標示偏低」的矛盾。
→ 三處改用四捨五入值，與需求條一致。

### 已確認「不是 bug」（稽核紀錄）
- 漂浮粒子 `floatfx` 有 `setTimeout` 移除，無記憶體洩漏。
- 即時衰減 `lastTick` 記帳正確，重整／存檔不會重複或漏算。
- 互動播放中 `liveTick`、`syncPull` 皆有 `sceneRunning` 防護；`.scene-on .petart{animation:none}` 已擋掉場景中的抖動殘留。
- 同步 race（前一版 #13）已修，本次再驗證仍正常。

### 驗證
- `node --check` 通過。
- 全面 smoke：7 動作 `finishScene`（低／高狀態）、各動作 `sceneSVG`/`sceneEnv` 多幀、**8 角色 × 7 需求狀態** `petSVG`、`liveTick`、含小數的 `careRound`/`needsHTML`/`petStatusLine`、`renderPet` → 全數**無例外、無 undefined／NaN**。
- 版本 `v1.8 · 微調修正版`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k

---
_Generated by [Claude Code](https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k)_