### PR TITLE
拿掉狀態文字字眼，改用 emoji＋顏色

### DIFF
--- a/public/3c.html
+++ b/public/3c.html
@@ -520,7 +520,7 @@
 (function () {
   "use strict";
 
-  var APP_VER = "v1.8 · 微調修正版 · 2026-06-20";
+  var APP_VER = "v1.9 · 圖示狀態版 · 2026-06-21";
   var STORAGE_KEY = "mt-3c-panel-v1";
   var HISTORY_KEY = "mt-3c-history-v1";
   var HISTORY_MAX = 30;
@@ -1687,14 +1687,13 @@
   function needsHTML(p) {
     return '<div class="stats">' + NEEDS.map(function (n) {
       var v = Math.round(p.needs[n.key] == null ? 80 : p.needs[n.key]); var lv = needTier(v);
-      var tag = lv ? ' <b class="ntag t' + lv + '">' + n.low + "</b>" : "";
-      return '<div class="stat"><span class="sl">' + n.emoji + " " + n.name + tag + '</span><div class="bar"><i class="bl' + lv + '" style="width:' + v + '%"></i></div></div>';
+      return '<div class="stat"><span class="sl">' + n.emoji + " " + n.name + '</span><div class="bar"><i class="bl' + lv + '" style="width:' + v + '%"></i></div></div>';
     }).join("") + "</div>";
   }
   function petStatusLine(p) {
     var lows = lowNeeds(p);
-    if (!lows.length) return '<div class="petstatus ok">😊 心情很好，跟你玩得開心～</div>';
-    return '<div class="petstatus need' + (lows[0].lv >= 3 ? " urgent" : "") + '">💬 ' + lows.map(function (n) { return NEED_MAP[n.key].low; }).join("、") + "！</div>";
+    if (!lows.length) return '<div class="petstatus ok">😊</div>';
+    return '<div class="petstatus need' + (lows[0].lv >= 3 ? " urgent" : "") + '">💬 ' + lows.map(function (n) { return NEED_MAP[n.key].emoji; }).join(" ") + "</div>";
   }
   function petAgeHTML(p) {
     var g = p.growth || 0, st = petStage(g), nx = nextStageAt(g), prev = [0, 15, 40, 80][st];
@@ -1773,8 +1772,8 @@
     var moodNow = (petExpr === "auto") ? petMood(p) : null;
     var artCls = (moodNow && moodNow.lv >= 3) ? " distress" : "";
     var bubble = "";
-    if (moodNow) { var nbb = NEED_MAP[moodNow.key]; bubble = '<div class="moodbubble t' + moodNow.lv + '">' + nbb.emoji + " " + nbb.low + "！</div>"; }
-    else if (petExpr === "auto" && petThriving(p)) bubble = '<div class="moodbubble happy">🥰 好幸福～</div>';
+    if (moodNow) { var nbb = NEED_MAP[moodNow.key]; bubble = '<div class="moodbubble t' + moodNow.lv + '">' + nbb.emoji + "❗</div>"; }
+    else if (petExpr === "auto" && petThriving(p)) bubble = '<div class="moodbubble happy">🥰</div>';
     $("view-pet").innerHTML =
       swRow +
       '<div class="petstage ' + ch.cls + '">' +
@@ -2130,10 +2129,10 @@
     if (!host) { host = document.createElement("div"); host.id = "stategallery"; document.body.appendChild(host); }
     var TIERS = [58, 38, 14];
     var h = '<div class="gwrap"><button class="gclose">✕ 關閉</button>' +
-      "<h1>🎭 寵物狀態圖鑑</h1><p class=\"ghint\">目前版本：" + APP_VER + "。掉到剩約 2/3 就開始有表情；同一隻兔兔，肚子餓／口渴／想睡／髒了／想尿尿／寂寞時會有不同表情，越低變化越明顯。</p>";
+      "<h1>🎭 寵物狀態圖鑑</h1><p class=\"ghint\">目前版本：" + APP_VER + "。需求掉到剩約 2/3 就開始有表情，越低變化越明顯。</p>";
     h += '<div class="ggrid">' + galleryCard("😊 健康", "", null) + "</div>";
     NEEDS.forEach(function (n) {
-      h += "<h3>" + n.emoji + " " + n.name + "（" + n.low + "）</h3><div class=\"ggrid\">";
+      h += "<h3>" + n.emoji + " " + n.name + "</h3><div class=\"ggrid\">";
       TIERS.forEach(function (v) { var nd = {}; nd[n.key] = v; h += galleryCard("剩 " + v + "%", "", nd); });
       h += "</div>";
     });


### PR DESCRIPTION
## 為什麼改

家長要求把「肚子餓／口渴／好累／好髒／想上廁所／想討抱」這類**狀態文字**從畫面上全部拿掉，改用 emoji 和顏色表達。只動 `public/3c.html`。

## 改了什麼

- **需求條**：只留「emoji＋名稱」（🍎 肚子、⚡ 精神…）；嚴重程度改由**條的顏色**（黃→橘→紅）表示，不再加「肚子餓」等字。
- **狀態列**：偏低時改顯示 emoji（`💬 🍎 💧`）；健康時只剩 `😊`。
- **頭上泡泡**：改成純 emoji（`🍎❗`）與 `🥰`，不再有文字。
- **狀態圖鑑（#states）**：標題與說明也拿掉那些字眼。

**保留**：「今天的故事」敘事卡與動作完成提示仍是完整句子（屬於敘事內容，不是狀態標籤）——如果這些也要改，再跟我說。

- 版本 `v1.9 · 圖示狀態版`。

## 驗證

- `node --check` 通過；確認需求條／狀態列函式已無「肚子餓／好累…」字眼。
- 全面 smoke（7 動作、各場景、8 角色×7 狀態 petSVG、liveTick、含小數顯示）→ 無例外、無 undefined／NaN。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k

---
_Generated by [Claude Code](https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k)_