### PR TITLE
修正：剛登記的睡眠紀錄被雲端同步洗掉而消失（資料遺失）

### DIFF
--- a/public/3c.html
+++ b/public/3c.html
@@ -520,7 +520,7 @@
 (function () {
   "use strict";
 
-  var APP_VER = "v1.9 · 圖示狀態版 · 2026-06-21";
+  var APP_VER = "v2.0 · 紀錄修復版 · 2026-06-21";
   var STORAGE_KEY = "mt-3c-panel-v1";
   var HISTORY_KEY = "mt-3c-history-v1";
   var HISTORY_MAX = 30;
@@ -691,17 +691,40 @@
       });
     });
   }
+  // 使用者輸入的資料（睡眠紀錄、使用紀錄、已購買裝扮）以 id 聯集合併，
+  // 雲端拉下來時「不覆蓋、不遺失」本機剛加但還沒推上去的紀錄。
+  function mergeById(local, remote) {
+    var byId = {}, order = [], addedLocal = false;
+    (remote || []).forEach(function (r) { if (r && r.id != null && !(r.id in byId)) { byId[r.id] = r; order.push(r.id); } });
+    (local || []).forEach(function (r) { if (r && r.id != null) { if (!(r.id in byId)) { order.push(r.id); addedLocal = true; } byId[r.id] = r; } });
+    return { arr: order.map(function (id) { return byId[id]; }), addedLocal: addedLocal };
+  }
+  function mergeInventory(local, remote) {
+    var out = {}, addedLocal = false;
+    ["mia", "tia", "self"].forEach(function (c) {
+      out[c] = {};
+      var rc = (remote && remote[c]) || {}, lc = (local && local[c]) || {};
+      Object.keys(rc).forEach(function (k) { if (rc[k]) out[c][k] = true; });
+      Object.keys(lc).forEach(function (k) { if (lc[k] && !out[c][k]) { out[c][k] = true; addedLocal = true; } });
+    });
+    return { inv: out, addedLocal: addedLocal };
+  }
   function applyCloudState(d) {
     try {
       var keepProfile = state.profile, keepLock = state.lock;   // 保留本機的「專屬機 / 家長鎖」設定
       var keepLive = capturePetLive(state);                     // 保留本機寵物的即時需求/計時
+      var locRecords = state.records, locUsages = state.usages, locInv = state.inventory;
       state = fromData(d);
       state.profile = keepProfile; state.lock = keepLock;
       restorePetLive(state, keepLive);
+      var rm = mergeById(locRecords, state.records); state.records = rm.arr;
+      var um = mergeById(locUsages, state.usages); state.usages = um.arr;
+      var im = mergeInventory(locInv, state.inventory); state.inventory = im.inv;
       lastSig = null;
       try { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); } catch (e) { }
       fillSettings(); $("profileSel").value = state.profile; applyProfile();
       render(); updateForm(); renderPet(); refreshLockSection(); applyLock();
+      if (rm.addedLocal || um.addedLocal || im.addedLocal) syncPush();   // 本機有雲端沒有的紀錄 → 補推回雲端
     } catch (e) { }
   }
   function syncPull(mode) {


### PR DESCRIPTION
## 症狀（家長回報）

剛登記一筆睡眠紀錄，**紀錄突然消失**。資料遺失，嚴重。

## 根因

`applyCloudState`（雲端拉取後套用）用 `state = fromData(d)` **整包覆蓋**本機狀態，包含 `records`。

關鍵時機：**在初次同步（seed pull）完成前就新增紀錄**——此時 `syncReady` 還是 false，`syncPush` 直接 return（不推送）。接著種子拉取回來，發現雲端有資料 → 用雲端的舊 `records` 蓋掉本機剛加的那筆，而那筆**從未推上雲端 → 永久消失**。

## 修正

使用者輸入的資料改成**以 id 聯集合併**，而不是覆蓋：

- `mergeById(local, remote)`：睡眠 `records`、使用 `usages` 以 `id` 聯集；本機剛加、雲端還沒有的紀錄**保留不丟**；衝突時以本機為準。
- `mergeInventory`：已購裝扮以聯集保留（不會弄丟剛換的造型）。
- 若本機有雲端沒有的紀錄 → 合併後**自動補推回雲端**，讓雲端補齊。
- 穩態（本機＝雲端）`addedLocal=false`，**不會多推、不會 ping-pong**。

版本 `v2.0 · 紀錄修復版`。

## 驗證

- `node --check` 通過；全面 smoke 無例外、無 undefined／NaN。
- 模擬實際情境：
  - **種子競態**：本機有剛加的 `r3`、雲端沒有 → 合併後 `r1,r2,r3`，**r3 保留 ✓**，`addedLocal=true`（會補推）。
  - **跨裝置**：本機 `r3`＋雲端 `r4` → 聯集兩者都在。
  - **穩態**：本機＝雲端 → 無多餘、`addedLocal=false`（無推送迴圈）。
  - **庫存**：mia 的 bow＋crown、tia 的 flower 正確聯集保留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k

---
_Generated by [Claude Code](https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k)_