### PR TITLE
華麗特效配件（越貴越浮誇）＋修背景「不戴」仍是花園

### DIFF
--- a/public/3c.html
+++ b/public/3c.html
@@ -527,7 +527,7 @@
 (function () {
   "use strict";
 
-  var APP_VER = "v2.2 · 看醫生版 · 2026-06-21";
+  var APP_VER = "v2.3 · 華麗配件版 · 2026-06-21";
   var STORAGE_KEY = "mt-3c-panel-v1";
   var HISTORY_KEY = "mt-3c-history-v1";
   var HISTORY_MAX = 30;
@@ -586,7 +586,7 @@
   function needTier(v) { return v >= 67 ? 0 : v >= 50 ? 1 : v >= 28 ? 2 : 3; }
   function defaultPet() {
     return { name: "", color: "theme",
-      wear: { hat: null, eyes: null, outfit: null, back: null, hand: null, bg: null, fx: null },
+      wear: { hat: null, eyes: null, outfit: null, back: null, hand: null, bg: "garden", fx: null },
       growth: 0, growthDay: "", growthToday: 0,
       needs: { hunger: 80, thirst: 80, energy: 80, clean: 80, bladder: 80, happy: 80 },
       storyDay: "", storyIdx: -1, sick: false, sickDay: "",
@@ -827,6 +827,19 @@
     var p = []; for (var i = 0; i < 10; i++) { var rr = (i % 2) ? r * 0.45 : r; var a = -Math.PI / 2 + i * Math.PI / 5; p.push([cx + rr * Math.cos(a), cy + rr * Math.sin(a)]); }
     return '<polygon points="' + pts(p) + '" fill="' + fill + '" stroke="' + stroke + '" stroke-width="1.4" stroke-linejoin="round"/>';
   }
+  // ===== 配件特效（華麗款專用）：柔光暈、放射光、環繞星 =====
+  function glowOrb(cx, cy, r, color, op) {
+    var g = "glo" + (++svgSeq);
+    return '<radialGradient id="' + g + '" cx="50%" cy="50%" r="50%"><stop offset="0" stop-color="' + color + '" stop-opacity="' + (op || 0.6) + '"/><stop offset="1" stop-color="' + color + '" stop-opacity="0"/></radialGradient><ellipse cx="' + cx + '" cy="' + cy + '" rx="' + r + '" ry="' + r + '" fill="url(#' + g + ')"/>';
+  }
+  function rays(cx, cy, n, r0, r1, color, w) {
+    var s = '<g stroke="' + color + '" stroke-width="' + (w || 1) + '" stroke-linecap="round" opacity=".7">';
+    for (var i = 0; i < n; i++) { var a = (i / n) * Math.PI * 2; s += '<line x1="' + (cx + Math.cos(a) * r0).toFixed(1) + '" y1="' + (cy + Math.sin(a) * r0).toFixed(1) + '" x2="' + (cx + Math.cos(a) * r1).toFixed(1) + '" y2="' + (cy + Math.sin(a) * r1).toFixed(1) + '"/>'; }
+    return s + "</g>";
+  }
+  function orbitStars(cx, cy, r, n, sz, color) {
+    var s = ""; for (var i = 0; i < n; i++) { var a = (i / n) * Math.PI * 2 + 0.5; s += star5(cx + Math.cos(a) * r, cy + Math.sin(a) * r, sz, color, color); } return s;
+  }
   // 顏色（底色）
   var COLORS = {
     pink: { fur: "#ff9ec9", dark: "#e25f9b", inner: "#ffd9ec", belly: "#fff4fa", cheek: "#ff5fa6" },
@@ -1014,10 +1027,23 @@
     if (id === "hearts") return FXP.map(function (p, i) { return fxHeart(p[0], p[1], 2.2 + (i % 2) * 0.9); }).join("");
     if (id === "stars") return FXP.map(function (p, i) { return (i % 2) ? sparkle(p[0], p[1], 2.6) : star5(p[0], p[1], 3, "#ffe066", "#e0a500"); }).join("");
     if (id === "confetti") { var cs = ["#ff5fa2", "#ffd23f", "#5fd0ff", "#8be3a0", "#c193ff"]; return FXP.map(function (p, i) { return '<rect x="' + p[0] + '" y="' + p[1] + '" width="3" height="4.4" rx="1" fill="' + cs[i % cs.length] + '" transform="rotate(' + ((i * 47) % 360) + ' ' + p[0] + ' ' + p[1] + ')"/>'; }).join(""); }
+    if (id === "aurora") {
+      var ag2 = "aur" + (++svgSeq);
+      var bands = "";
+      [["#8be3c0", 18], ["#8fd0ff", 26], ["#c193ff", 34]].forEach(function (b, i) {
+        bands += '<path d="M-2 ' + b[1] + ' Q25 ' + (b[1] - 10) + ' 50 ' + b[1] + ' T102 ' + (b[1] - 4) + '" fill="none" stroke="' + b[0] + '" stroke-width="7" stroke-linecap="round" opacity=".5"/>';
+      });
+      return '<defs></defs>' + bands + sparkle(16, 20, 2.4) + sparkle(40, 14, 2) + sparkle(66, 24, 2.2) + sparkle(86, 16, 2.4) + sparkle(28, 30, 1.8) + sparkle(74, 34, 1.8);
+    }
+    if (id === "fireworks") {
+      var pts2 = [[22, 22, "#ff5fa2"], [76, 26, "#ffd23f"], [50, 16, "#5fd0ff"], [30, 60, "#8be3a0"], [82, 62, "#c193ff"]];
+      return pts2.map(function (p) { return rays(p[0], p[1], 10, 2, 7, p[2], 1.4) + '<circle cx="' + p[0] + '" cy="' + p[1] + '" r="1.6" fill="#fff"/>' + sparkle(p[0], p[1], 1.6); }).join("");
+    }
     return "";
   }
   function treeBg(x, y) { return '<rect x="' + (x - 1.6) + '" y="' + y + '" width="3.2" height="9" fill="#9a6638"/><polygon points="' + (x - 8) + ',' + y + ' ' + x + ',' + (y - 17) + ' ' + (x + 8) + ',' + y + '" fill="#6fc46f"/><polygon points="' + (x - 6) + ',' + (y - 7) + ' ' + x + ',' + (y - 22) + ' ' + (x + 6) + ',' + (y - 7) + '" fill="#80d080"/>'; }
   function drawBg(id) {
+    if (id === "plain") { var gpl = "bgpl" + (++svgSeq); return '<linearGradient id="' + gpl + '" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#eef1fa"/><stop offset="1" stop-color="#dde3f1"/></linearGradient><rect width="100" height="100" fill="url(#' + gpl + ')"/><ellipse cx="50" cy="88" rx="32" ry="5.5" fill="#000" opacity=".04"/>'; }
     if (id === "castle") { var gc = "bgc" + (++svgSeq); return '<linearGradient id="' + gc + '" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#bcd0ff"/><stop offset="1" stop-color="#ead9ff"/></linearGradient><rect width="100" height="100" fill="url(#' + gc + ')"/><g fill="#b29ce0" stroke="#9a85cc" stroke-width="1" stroke-linejoin="round"><rect x="13" y="42" width="13" height="40"/><rect x="74" y="42" width="13" height="40"/><rect x="38" y="34" width="24" height="48"/><polygon points="10,42 19.5,30 29,42"/><polygon points="71,42 80.5,30 90,42"/><polygon points="34,34 50,18 66,34"/></g><g fill="#8f78c4"><rect x="46" y="60" width="8" height="22" rx="3"/><rect x="17" y="52" width="5" height="6"/><rect x="78" y="52" width="5" height="6"/></g><circle cx="84" cy="16" r="7" fill="#fff3b0"/>'; }
     if (id === "forest") return '<rect width="100" height="100" fill="#dff3df"/><circle cx="20" cy="16" r="8" fill="#ffe08a"/><path d="M0 84 Q50 76 100 84 V100 H0 Z" fill="#a8e0a8"/>' + treeBg(16, 80) + treeBg(40, 84) + treeBg(64, 82) + treeBg(86, 80);
     if (id === "sakura") return '<rect width="100" height="100" fill="#ffe6f2"/><circle cx="82" cy="16" r="7" fill="#fff3b0"/><path d="M0 66 Q22 48 46 56 Q32 62 26 78" fill="none" stroke="#9a6b4a" stroke-width="3.2" stroke-linecap="round"/>' + [[10, 60], [20, 50], [31, 57], [41, 53], [16, 70], [37, 66]].map(function (p) { return '<circle cx="' + p[0] + '" cy="' + p[1] + '" r="4.2" fill="#ffb3d9"/><circle cx="' + p[0] + '" cy="' + p[1] + '" r="1.6" fill="#ff7eb6"/>'; }).join("");
@@ -1088,6 +1114,15 @@
         '<g fill="none" stroke="#ffd76a" stroke-width="1.1"><path d="' + pf + '"/><g transform="translate(100,0) scale(-1,1)"><path d="' + pf + '"/></g></g></g>' +
         star5(50, 85, 3, "#ffd23f", "#e0a500") + sparkle(7, 29, 3) + sparkle(93, 29, 3) + sparkle(20, 57, 2.2) + sparkle(80, 57, 2.2);
     }
+    if (id === "rainbowwing") {
+      var rb = "rbw" + (++svgSeq);
+      var rw = "M58 49 C71 22,99 16,99 31 Q89 35 98 43 Q85 45 94 53 Q81 55 90 63 Q77 64 84 73 C70 67,62 56,58 53 Z";
+      return '<defs><linearGradient id="' + rb + '" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#ff8fa3"/><stop offset=".25" stop-color="#ffd36e"/><stop offset=".5" stop-color="#9be59b"/><stop offset=".75" stop-color="#8fd0ff"/><stop offset="1" stop-color="#c9a3ff"/></linearGradient></defs>' +
+        glowOrb(50, 50, 52, "#ffffff", 0.55) + rays(50, 50, 14, 30, 52, "#fff7c0", 1.1) +
+        '<g stroke="#fff" stroke-width="1.7" stroke-linejoin="round" stroke-linecap="round">' +
+        '<path d="' + rw + '" fill="url(#' + rb + ')"/><g transform="translate(100,0) scale(-1,1)"><path d="' + rw + '" fill="url(#' + rb + ')"/></g></g>' +
+        sparkle(7, 24, 3.4) + sparkle(93, 24, 3.4) + sparkle(50, 13, 3) + sparkle(50, 86, 2.8) + sparkle(18, 56, 2.6) + sparkle(82, 56, 2.6);
+    }
     return "";
   }
   function drawOutfitBehind(id) {
@@ -1135,6 +1170,16 @@
         '<path d="M52.5 95 H59.5 M53 93 H59" stroke="' + sk + '" stroke-width="1" stroke-linecap="round"/>';
     }
     if (id === "cape") return '<circle cx="28" cy="55" r="3.4" fill="#ffd23f" stroke="#e0a500" stroke-width="1.3"/><circle cx="72" cy="55" r="3.4" fill="#ffd23f" stroke="#e0a500" stroke-width="1.3"/><circle cx="27" cy="54" r="1.2" fill="#fff7c0"/><circle cx="71" cy="54" r="1.2" fill="#fff7c0"/>';
+    if (id === "goddess") {
+      var gd2 = "gds" + (++svgSeq);
+      return '<defs><linearGradient id="' + gd2 + '" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#dbe6ff"/><stop offset="1" stop-color="#b89bff"/></linearGradient></defs>' +
+        glowOrb(50, 86, 30, "#cdb6ff", 0.5) +
+        '<path d="M33 76 C12 81,3 92,3 98 Q20 102 31 97 Q40 102 50 97 Q60 102 69 97 Q80 102 97 98 C97 92,88 81,67 76 Z" fill="url(#' + gd2 + ')" stroke="#9a85cc" stroke-width="1.6" stroke-linejoin="round"/>' +
+        '<path d="M34 82 Q50 88 66 82" fill="none" stroke="#fff" stroke-width="1.2" opacity=".5"/>' +
+        '<rect x="33" y="74.5" width="34" height="4.4" rx="2.2" fill="#fff" opacity=".92"/>' +
+        '<g fill="#fff"><circle cx="20" cy="92" r="1.7"/><circle cx="35" cy="95" r="1.7"/><circle cx="50" cy="96" r="1.7"/><circle cx="65" cy="95" r="1.7"/><circle cx="80" cy="92" r="1.7"/></g>' +
+        star5(24, 86, 2.6, "#fff3a0", "#e0c060") + star5(76, 86, 2.6, "#fff3a0", "#e0c060") + sparkle(15, 90, 2.4) + sparkle(85, 90, 2.4) + sparkle(50, 93, 2);
+    }
     return "";
   }
   function drawEyes(id) {
@@ -1143,6 +1188,8 @@
     if (id === "heart") return '<g fill="#2b2b3d" stroke="#1a1a26" stroke-width="0.8" stroke-linejoin="round"><path d="M40 51 C36.5 46.5,30.5 48.5,30.5 53.5 C30.5 57.5,36 60.5,40 64 C44 60.5,49.5 57.5,49.5 53.5 C49.5 48.5,43.5 46.5,40 51 Z"/><path d="M60 51 C56.5 46.5,50.5 48.5,50.5 53.5 C50.5 57.5,56 60.5,60 64 C64 60.5,69.5 57.5,69.5 53.5 C69.5 48.5,63.5 46.5,60 51 Z"/></g><path d="M49.5 53 H50.5" stroke="#2b2b3d" stroke-width="2.6"/><path d="M35 52.5 q2.5 -1.5 5 -0.3 M55 52.5 q2.5 -1.5 5 -0.3" stroke="#ff9ad6" stroke-width="1.5" fill="none" stroke-linecap="round" opacity=".85"/>';
     if (id === "star") return star5(40, 56, 7.5, "#cdeeff", "#5a9fd0") + star5(60, 56, 7.5, "#cdeeff", "#5a9fd0") + '<path d="M47.5 56 H52.5" stroke="#5a9fd0" stroke-width="2"/>';
     if (id === "shades") return '<g fill="#2b2b3d" stroke="#1a1a26" stroke-width="1"><path d="M31 51 H46 Q47 60 38.5 60 Q31 60 31 51 Z"/><path d="M69 51 H54 Q53 60 61.5 60 Q69 60 69 51 Z"/><rect x="46" y="52.5" width="8" height="2.2"/></g>';
+    if (id === "diamond") return '<g fill="#dff3ff" fill-opacity=".5" stroke="#7fc7ff" stroke-width="2.2"><circle cx="40" cy="56" r="7.8"/><circle cx="60" cy="56" r="7.8"/></g><path d="M47.5 55 H52.5 M32 54 L26 49 M68 54 L74 49" fill="none" stroke="#7fc7ff" stroke-width="2.2" stroke-linecap="round"/>' +
+      sparkle(43, 52, 2.4) + sparkle(63, 52, 2.4) + sparkle(37, 59, 1.6) + sparkle(57, 59, 1.6) + sparkle(50, 47, 1.6);
     return "";
   }
   function drawHat(id, R) {
@@ -1165,6 +1212,12 @@
     if (id === "tophat") return '<rect x="38" y="2" width="24" height="19" rx="2.5" fill="#3a3550" stroke="#262138" stroke-width="1.5"/><rect x="30" y="20" width="40" height="5" rx="2.5" fill="#3a3550" stroke="#262138" stroke-width="1.5"/><rect x="38" y="15" width="24" height="5" fill="#ff5277"/><rect x="41" y="5" width="3" height="11" rx="1.5" fill="#fff" opacity=".2"/>';
     if (id === "cap") return '<path d="M31 24 Q50 4 69 22 Q50 16 31 24 Z" fill="' + R.cheek + '" stroke="' + R.strokeC + '" stroke-width="1.4" stroke-linejoin="round"/><path d="M64 21 Q82 21 85 28 Q73 26 62 24 Z" fill="' + R.cheek + '" stroke="' + R.strokeC + '" stroke-width="1.4" stroke-linejoin="round"/><circle cx="50" cy="9" r="2.6" fill="' + R.strokeC + '"/>';
     if (id === "halo") return '<ellipse cx="50" cy="7" rx="17" ry="6.4" fill="none" stroke="#ffe066" stroke-width="1" opacity=".4"/><ellipse cx="50" cy="7" rx="14" ry="5" fill="none" stroke="#ffd23f" stroke-width="4"/><ellipse cx="50" cy="7" rx="14" ry="5" fill="none" stroke="#fff6c0" stroke-width="1.4"/>';
+    if (id === "starcrown") return glowOrb(50, 13, 20, "#ffe9a8", 0.7) + rays(50, 13, 10, 14, 22, "#fff3a0", 1) +
+      '<path d="M33 25 L36 7 L44 17 L50 3 L56 17 L64 7 L67 25 Z" fill="#ffd24a" stroke="#e0a500" stroke-width="2" stroke-linejoin="round"/>' +
+      '<rect x="32" y="24" width="36" height="5.2" rx="1.8" fill="#ffd24a" stroke="#e0a500" stroke-width="1.6"/>' +
+      '<circle cx="36" cy="7" r="2.6" fill="#ff5277" stroke="#e0a500" stroke-width="0.8"/><circle cx="50" cy="3" r="3.2" fill="#8fd0ff" stroke="#e0a500" stroke-width="0.8"/><circle cx="64" cy="7" r="2.6" fill="#ff5277" stroke="#e0a500" stroke-width="0.8"/>' +
+      '<circle cx="42" cy="26.4" r="1.6" fill="#ff5277"/><circle cx="50" cy="26.4" r="1.8" fill="#8fd0ff"/><circle cx="58" cy="26.4" r="1.6" fill="#ff5277"/>' +
+      orbitStars(50, 12, 27, 5, 2.4, "#fff7c0") + sparkle(50, 1, 2.6) + sparkle(28, 12, 2) + sparkle(72, 12, 2);
     return "";
   }
   function drawHand(id, R) {
@@ -1176,6 +1229,11 @@
     if (id === "lollipop") return '<line x1="74" y1="86" x2="86" y2="54" stroke="#e8d6b0" stroke-width="2.8" stroke-linecap="round"/><circle cx="87" cy="48" r="9.5" fill="#ff8fc2" stroke="#e25f9b" stroke-width="1.7"/><path d="M87 48 m-6.5 0 a6.5 6.5 0 1 1 13 0 a3.8 3.8 0 1 1 -7.6 0" fill="none" stroke="#fff" stroke-width="1.7"/>';
     if (id === "bouquet") return '<path d="M78 86 L85 60 M82 84 L89 62 M80 85 L86 61" stroke="#5fa83f" stroke-width="2"/><g stroke="#e0699a" stroke-width="1.3"><circle cx="84" cy="56" r="4.4" fill="#ff8fc2"/><circle cx="92" cy="58" r="4.4" fill="#ffd36e"/><circle cx="88" cy="50" r="4.4" fill="#b08fff"/></g><circle cx="84" cy="56" r="1.8" fill="#fff7d0"/><circle cx="92" cy="58" r="1.8" fill="#fff"/><circle cx="88" cy="50" r="1.8" fill="#fff"/>';
     if (id === "sword") return '<line x1="72" y1="88" x2="92" y2="52" stroke="#dfe6ef" stroke-width="4.4" stroke-linecap="round"/><line x1="92" y1="52" x2="94" y2="48" stroke="#fff" stroke-width="2.2"/><line x1="66" y1="82" x2="80" y2="74" stroke="#caa15a" stroke-width="3.6" stroke-linecap="round"/><circle cx="70" cy="84" r="2.8" fill="#ffd23f" stroke="#e0a500" stroke-width="1"/>';
+    if (id === "genesis") return '<line x1="80" y1="95" x2="80" y2="50" stroke="#caa15a" stroke-width="3.8" stroke-linecap="round"/><line x1="80" y1="95" x2="80" y2="50" stroke="#e7cf9a" stroke-width="1.4" stroke-linecap="round"/>' +
+      glowOrb(80, 42, 19, "#b15cff", 0.7) + rays(80, 42, 12, 9, 18, "#e6c0ff", 1) +
+      '<circle cx="80" cy="42" r="8" fill="#b15cff" stroke="#7d3fd0" stroke-width="1.6"/><circle cx="77.4" cy="39.4" r="2.6" fill="#fff" opacity=".7"/>' +
+      star5(80, 42, 4.4, "#fff", "#e0b0ff") + orbitStars(80, 42, 14, 6, 1.8, "#ecd6ff") +
+      sparkle(91, 34, 2.6) + sparkle(69, 48, 2.2) + sparkle(86, 52, 1.8) + sparkle(73, 36, 1.8);
     return "";
   }
   // ----- shared body builder (creature + worn items) -----
@@ -1330,14 +1388,16 @@
       { id: "cap", name: "鴨舌帽", emoji: "🧢", price: 25 },
       { id: "halo", name: "光環", emoji: "😇", price: 40 },
       { id: "bunnyears", name: "兔耳髮箍", emoji: "👂", price: 20 },
-      { id: "antlers", name: "鹿角", emoji: "🦌", price: 35 }
+      { id: "antlers", name: "鹿角", emoji: "🦌", price: 35 },
+      { id: "starcrown", name: "星辰皇冠", emoji: "👑", price: 120, limited: true, unlockStreak: 7 }
     ],
     eyes: [
       { id: "glasses", name: "圓眼鏡", emoji: "👓", price: 0 },
       { id: "star", name: "星星眼鏡", emoji: "🤩", price: 25 },
       { id: "heart", name: "愛心墨鏡", emoji: "😍", price: 30 },
       { id: "shades", name: "太陽眼鏡", emoji: "😎", price: 30 },
-      { id: "mask", name: "華麗面具", emoji: "🎭", price: 45 }
+      { id: "mask", name: "華麗面具", emoji: "🎭", price: 45 },
+      { id: "diamond", name: "鑽石眼鏡", emoji: "💎", price: 55 }
     ],
     outfit: [
       { id: "dress", name: "小洋裝", emoji: "👗", price: 0 },
@@ -1345,13 +1405,15 @@
       { id: "scarf", name: "圍巾", emoji: "🧣", price: 20 },
       { id: "tutu", name: "蓬蓬裙", emoji: "🩰", price: 30 },
       { id: "cape", name: "英雄斗篷", emoji: "🦸", price: 45 },
-      { id: "gown", name: "公主蓬裙", emoji: "👸", price: 70 }
+      { id: "gown", name: "公主蓬裙", emoji: "👸", price: 70 },
+      { id: "goddess", name: "星光女神裙", emoji: "🌟", price: 140, limited: true, unlockStreak: 7 }
     ],
     back: [
       { id: "wings", name: "天使翅膀", emoji: "😇", price: 60 },
       { id: "dragon", name: "龍之翼", emoji: "🐉", price: 70 },
       { id: "butterfly", name: "蝴蝶翅膀", emoji: "🦋", price: 90, limited: true, unlockStreak: 14 },
-      { id: "phoenix", name: "鳳凰火翼", emoji: "🔥", price: 150, limited: true, unlockStreak: 14 }
+      { id: "phoenix", name: "鳳凰火翼", emoji: "🔥", price: 150, limited: true, unlockStreak: 14 },
+      { id: "rainbowwing", name: "聖光彩翼", emoji: "🌈", price: 220, limited: true, unlockStreak: 14 }
     ],
     hand: [
       { id: "balloon", name: "氣球", emoji: "🎈", price: 0 },
@@ -1361,9 +1423,11 @@
       { id: "wand", name: "魔法棒", emoji: "🪄", price: 35 },
       { id: "sword", name: "寶劍", emoji: "⚔️", price: 40 },
       { id: "teddy", name: "小熊", emoji: "🧸", price: 30 },
-      { id: "scepter", name: "權杖", emoji: "🔮", price: 60 }
+      { id: "scepter", name: "權杖", emoji: "🔮", price: 60 },
+      { id: "genesis", name: "創世法杖", emoji: "🪄", price: 160, limited: true, unlockStreak: 14 }
     ],
     bg: [
+      { id: "plain", name: "簡約", emoji: "⬜", price: 0 },
       { id: "rainbow", name: "彩虹", emoji: "🌈", price: 0 },
       { id: "garden", name: "花園", emoji: "🌷", price: 0 },
       { id: "forest", name: "森林", emoji: "🌳", price: 30 },
@@ -1382,7 +1446,9 @@
       { id: "snow", name: "雪花", emoji: "❄️", price: 20 },
       { id: "confetti", name: "彩帶", emoji: "🎊", price: 20 },
       { id: "hearts", name: "愛心雨", emoji: "💕", price: 25 },
-      { id: "stars", name: "星星雨", emoji: "✨", price: 30 }
+      { id: "stars", name: "星星雨", emoji: "✨", price: 30 },
+      { id: "aurora", name: "極光", emoji: "🌌", price: 45, limited: true, unlockStreak: 7 },
+      { id: "fireworks", name: "煙火", emoji: "🎆", price: 55, limited: true, unlockStreak: 7 }
     ]
   };
   function findItem(slot, id) { var l = ITEMS[slot] || []; for (var i = 0; i < l.length; i++) if (l[i].id === id) return l[i]; return null; }
@@ -1814,7 +1880,7 @@
     var p = activePet(childKey);
     var worn = (slotKey === "color") ? p.color : p.wear[slotKey];
     var out = "";
-    if (slotKey !== "color") out += itemBtn(childKey, slotKey, { id: null, name: "不戴", emoji: "🚫", price: 0 }, worn == null);
+    if (slotKey !== "color" && slotKey !== "bg") out += itemBtn(childKey, slotKey, { id: null, name: "不戴", emoji: "🚫", price: 0 }, worn == null);
     (ITEMS[slotKey] || []).forEach(function (it) { out += itemBtn(childKey, slotKey, it, worn === it.id); });
     return '<div class="wardrobe">' + out + "</div>";
   }


### PR DESCRIPTION
## 需求

1. **配件再增加**，越後面（越貴）→ 越華麗、**特效越浮誇、尺寸越大**，但仍要符合整體美觀。
2. 順手回報：背景選「不戴」結果**還是花園背景**。

只動 `public/3c.html`。

## 改了什麼

**1. 頂級「特效配件」（配件特效＝配件自帶的光暈／放射光／環繞星／火花）**
新增效果工具：`glowOrb`（柔光暈）、`rays`（放射光）、`orbitStars`（環繞星）。各欄位加一個越貴越浮誇的頂級款：

| 欄位 | 新配件 | 價格 | 特效 |
|---|---|---|---|
| 背飾 | 🌈 聖光彩翼 | **220** | 彩虹巨翼＋柔光暈＋14 道放射光 |
| 手持 | 🪄 創世法杖 | 160 | 發光寶珠＋放射光＋環繞光點 |
| 衣服 | 🌟 星光女神裙 | 140 | 流光長裙＋柔光＋星星 |
| 頭飾 | 👑 星辰皇冠 | 120 | 皇冠＋光暈＋5 顆環繞星 |
| 眼鏡 | 💎 鑽石眼鏡 | 55 | 鏡片閃光 |
| 特效 | 🎆 煙火 / 🌌 極光 | 55 / 45 | 爆裂火花 / 滿版光帶 |

- 背飾價格—衝擊遞增：天使(60)→龍(70)→蝴蝶(90)→鳳凰(150)→**聖光彩翼(220)**。
- 商店沿用上版「所見即所得」，**直接顯示實際特效**（不會買了才發現不一樣）。
- 背飾 `rainbow` 改 id 為 `rainbowwing`，避免和「顏色/背景的 rainbow」**共用庫存**（否則買便宜的色就會解鎖貴的翼）。

**2. 修背景「不戴」仍是花園**
- 原因：場景背景 `null` 會 fallback 成 garden，所以「不戴」＝花園。
- 改法：場景一定要有背景 → 移除 bg 的「不戴」選項，改提供 **「⬜ 簡約」乾淨背景**；預設背景明確設為「花園」。

版本 `v2.3 · 華麗配件版`。

## 驗證

- `node --check`＋全面 smoke → 無例外、無 undefined／NaN。
- `@resvg` 實際渲染 8 款新配件＋簡約背景：聖光彩翼／星辰皇冠／創世法杖／星光女神裙／鑽石眼鏡／極光／煙火／簡約背景，光暈・放射光・環繞星・火花皆正確、0 壞字元、整體仍可愛協調。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k

---
_Generated by [Claude Code](https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k)_