### PR TITLE
配件改八級制：每欄位 3 免費＋分級特效（不擋臉、越貴越華麗）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Dependencies (installed locally only, e.g. for rendering/test tooling)
+node_modules/
+
+# Logs
+npm-debug.log*
+*.log
+
+# OS / editor cruft
+.DS_Store

--- a/public/3c.html
+++ b/public/3c.html
@@ -527,7 +527,7 @@
 (function () {
   "use strict";
 
-  var APP_VER = "v2.3 · 華麗配件版 · 2026-06-21";
+  var APP_VER = "v2.4 · 八級配件版 · 2026-06-21";
   var STORAGE_KEY = "mt-3c-panel-v1";
   var HISTORY_KEY = "mt-3c-history-v1";
   var HISTORY_MAX = 30;
@@ -653,9 +653,19 @@
       lock: (d.lock && typeof d.lock === "object") ? { on: !!d.lock.on, hash: typeof d.lock.hash === "string" ? d.lock.hash : "" } : { on: false, hash: "" }
     };
   }
+  // 「天藍」原本免費，改 8 級制後變付費；用 settings.gf1 標記是否已處理（隨存檔持久化、會跟著雲端同步）
+  // 更新前就有資料（沒有 gf1 標記）的使用者 → 補發原免費配件；全新使用者一開始就標記，不發放
+  function grandfatherFree(st) {
+    ["mia", "tia", "self"].forEach(function (c) { if (!st.inventory[c]) st.inventory[c] = {}; st.inventory[c].blue = true; });
+  }
+  function freshBlank() { var b = blank(); b.settings.gf1 = 1; return b; }
   function load() {
-    try { var raw = localStorage.getItem(STORAGE_KEY); if (!raw) return blank(); return fromData(JSON.parse(raw)); }
-    catch (e) { return blank(); }
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY); if (!raw) return freshBlank();
+      var st = fromData(JSON.parse(raw));
+      if (!st.settings.gf1) { grandfatherFree(st); st.settings.gf1 = 1; }   // 舊資料沒標記 → 補發、補標記
+      return st;
+    } catch (e) { return freshBlank(); }
   }
   function save() {
     try { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); }
@@ -839,6 +849,33 @@
   }
   function orbitStars(cx, cy, r, n, sz, color) {
     var s = ""; for (var i = 0; i < n; i++) { var a = (i / n) * Math.PI * 2 + 0.5; s += star5(cx + Math.cos(a) * r, cy + Math.sin(a) * r, sz, color, color); } return s;
+  }
+  // ===== 配件分級特效：等級越高越浮誇，但「永遠避開臉部」、柔光在後、閃粉在前 =====
+  // 臉部保留區（本地座標）：閃粉／星星不會畫進來，保持五官清晰
+  function inFace(x, y) { return x > 31 && x < 69 && y > 32 && y < 64; }
+  // 背光層：柔光暈＋放射光（畫在角色後方、半透明，純粹當光暈不擋臉）
+  function tierAura(cx, cy, sp, tier) {
+    tier = tier || 1; if (tier < 5) return "";
+    var halo = tier >= 8 ? "#ffe89a" : "#ffd76a", s = "";
+    s += glowOrb(cx, cy, sp * (1.0 + (tier - 5) * 0.42), halo, 0.26 + (tier - 5) * 0.08);   // 柔光暈：tier5 起
+    if (tier >= 6) s += rays(cx, cy, tier >= 8 ? 16 : (tier >= 7 ? 12 : 10), sp * 0.8, sp * (1.35 + (tier - 6) * 0.4), halo, tier >= 8 ? 1.4 : 1.0);  // 放射光芒：tier6 起
+    return s;
+  }
+  // 前景層：環繞星＋閃粉（畫在最上層，但落在臉部保留區的一律略過）
+  function tierSparkle(cx, cy, sp, tier) {
+    tier = tier || 1; if (tier <= 3) return "";
+    var spk = tier >= 8 ? "#fff7d8" : "#fff", s = "";
+    function star(px, py, r, c) { return inFace(px, py) ? "" : star5(px, py, r, c, c); }
+    function spk1(px, py, r) { return inFace(px, py) ? "" : sparkle(px, py, r); }
+    if (tier >= 7) { var n1 = tier >= 8 ? 9 : 6, r1 = sp * 1.5; for (var i = 0; i < n1; i++) { var a1 = (i / n1) * Math.PI * 2 + 0.5; s += star(cx + Math.cos(a1) * r1, cy + Math.sin(a1) * r1, sp * 0.17, spk); } }  // 環繞星：tier7 起一圈（尺寸節制）
+    var n = tier >= 8 ? 8 : (tier - 2), ring = sp * 1.25;   // 閃粉：t4=2 … t8=8（不再暴量）
+    for (var k = 0; k < n; k++) { var a = (k / n) * Math.PI * 2 + 0.35, rr = ring * (0.72 + (k % 3) * 0.16); s += spk1(cx + Math.cos(a) * rr, cy + Math.sin(a) * rr, sp * ((k % 2) ? 0.16 : 0.24)); }
+    return s;
+  }
+  // 等級越高、配件尺寸略放大（繞配件中心縮放，tier 1–3 維持原寸）
+  function tierScale(svg, cx, cy, tier) {
+    if (!tier || tier <= 3) return svg; var k = 1 + (tier - 3) * 0.035;
+    return '<g transform="translate(' + cx + ' ' + cy + ') scale(' + k.toFixed(3) + ') translate(' + (-cx) + ' ' + (-cy) + ')">' + svg + '</g>';
   }
   // 顏色（底色）
   var COLORS = {
@@ -1247,14 +1284,29 @@
     omit = omit || {};
     var R = resolveColor(childKey, p.color || "theme"), wear = p.wear || {}, inner = "";
     if (p.color === "galaxy") inner += galaxyAura();
+    var thT = itemTier("hat", wear.hat), toT = itemTier("outfit", wear.outfit), tbT = itemTier("back", wear.back), tnT = itemTier("hand", wear.hand);
+    // 1) 背光層（柔光暈＋放射光）畫在角色後方、半透明，不擋臉
+    var aura = "";
+    if (wear.back && !omit.back) aura += tierAura(50, 50, 20, tbT);
+    if (wear.outfit && !omit.outfit) aura += tierAura(50, 74, 15, toT);
+    if (wear.hat && !omit.hat) aura += tierAura(50, 16, 16, thT);
+    if (wear.hand && !omit.hand) aura += tierAura(79, 50, 13, tnT);
+    if (aura) inner += '<g opacity="0.85">' + aura + "</g>";
+    // 2) 角色與配件本體（配件依等級略放大）
     if (wear.back && !omit.back) inner += drawBack(wear.back);
     if (wear.outfit && !omit.outfit) inner += drawOutfitBehind(wear.outfit);
     inner += drawCreature(species, R, expr, lv);
-    if (wear.outfit && !omit.outfit) inner += drawOutfit(wear.outfit, R);
+    if (wear.outfit && !omit.outfit) inner += tierScale(drawOutfit(wear.outfit, R), 50, 74, toT);
     if (wear.eyes && !omit.eyes) inner += drawEyes(wear.eyes);
-    if (wear.hat && !omit.hat) inner += drawHat(wear.hat, R);
-    if (wear.hand && !omit.hand) inner += drawHand(wear.hand, R);
-    inner += colorSparkles(p.color);
+    if (wear.hat && !omit.hat) inner += tierScale(drawHat(wear.hat, R), 50, 16, thT);
+    if (wear.hand && !omit.hand) inner += tierScale(drawHand(wear.hand, R), 80, 64, tnT);
+    // 3) 前景閃粉／環繞星畫在最上層，但避開臉部保留區
+    var spk = "";
+    if (wear.back && !omit.back) spk += tierSparkle(50, 50, 20, tbT);
+    if (wear.outfit && !omit.outfit) spk += tierSparkle(50, 74, 15, toT);
+    if (wear.hat && !omit.hat) spk += tierSparkle(50, 16, 16, thT);
+    if (wear.hand && !omit.hand) spk += tierSparkle(79, 50, 13, tnT);
+    inner += spk + colorSparkles(p.color);
     return { R: R, grad: R.grad, inner: inner };
   }
 
@@ -1355,6 +1407,10 @@
     { key: "eyes", name: "眼鏡" }, { key: "outfit", name: "衣服" }, { key: "back", name: "背飾" },
     { key: "hand", name: "手持" }, { key: "bg", name: "背景" }, { key: "fx", name: "特效" }
   ];
+  // 8 級制：每個欄位前 3 級免費，第 4 級起越高越貴；price 沒寫就由等級換算
+  var TIER_PRICE = [0, 0, 0, 0, 20, 40, 70, 110, 180];
+  function itemPrice(it) { if (!it) return 0; if (typeof it.price === "number") return it.price; return TIER_PRICE[it.tier || 1] || 0; }
+  function itemTier(slot, id) { var it = findItem(slot, id); return (it && it.tier) || 1; }
   var ITEMS = {
     species: [
       { id: "bunny", name: "兔兔", emoji: "🐰", price: 0 },
@@ -1367,94 +1423,94 @@
       { id: "unicorn", name: "獨角獸", emoji: "🦄", price: 120, limited: true, unlockStreak: 7 }
     ],
     color: [
-      { id: "theme", name: "原色", emoji: "⭐", price: 0 },
-      { id: "pink", name: "粉紅", emoji: "💗", price: 0 },
-      { id: "purple", name: "紫色", emoji: "💜", price: 0 },
-      { id: "blue", name: "天藍", emoji: "💙", price: 0 },
-      { id: "mint", name: "薄荷", emoji: "💚", price: 20 },
-      { id: "peach", name: "蜜桃", emoji: "🧡", price: 20 },
-      { id: "cream", name: "奶油", emoji: "💛", price: 20 },
-      { id: "grey", name: "灰色", emoji: "🌫️", price: 20 },
-      { id: "rainbow", name: "彩虹", emoji: "🌈", price: 60 },
-      { id: "galaxy", name: "星空", emoji: "✨", price: 180, limited: true, unlockStreak: 7 }
+      { id: "theme", name: "原色", emoji: "⭐", tier: 1 },
+      { id: "pink", name: "粉紅", emoji: "💗", tier: 2 },
+      { id: "purple", name: "紫色", emoji: "💜", tier: 3 },
+      { id: "blue", name: "天藍", emoji: "💙", tier: 4 },
+      { id: "mint", name: "薄荷", emoji: "💚", tier: 4 },
+      { id: "peach", name: "蜜桃", emoji: "🧡", tier: 5 },
+      { id: "cream", name: "奶油", emoji: "💛", tier: 5 },
+      { id: "grey", name: "灰色", emoji: "🌫️", tier: 5 },
+      { id: "rainbow", name: "彩虹", emoji: "🌈", tier: 6 },
+      { id: "galaxy", name: "星空", emoji: "✨", tier: 8, limited: true, unlockStreak: 7 }
     ],
     hat: [
-      { id: "crown", name: "皇冠", emoji: "👑", price: 0 },
-      { id: "bow", name: "蝴蝶結", emoji: "🎀", price: 0 },
-      { id: "flower", name: "小花", emoji: "🌼", price: 20 },
-      { id: "party", name: "派對帽", emoji: "🥳", price: 30 },
-      { id: "beanie", name: "毛帽", emoji: "🧢", price: 20 },
-      { id: "tophat", name: "紳士帽", emoji: "🎩", price: 35 },
-      { id: "cap", name: "鴨舌帽", emoji: "🧢", price: 25 },
-      { id: "halo", name: "光環", emoji: "😇", price: 40 },
-      { id: "bunnyears", name: "兔耳髮箍", emoji: "👂", price: 20 },
-      { id: "antlers", name: "鹿角", emoji: "🦌", price: 35 },
-      { id: "starcrown", name: "星辰皇冠", emoji: "👑", price: 120, limited: true, unlockStreak: 7 }
+      { id: "bow", name: "蝴蝶結", emoji: "🎀", tier: 1 },
+      { id: "bunnyears", name: "兔耳髮箍", emoji: "👂", tier: 2 },
+      { id: "crown", name: "皇冠", emoji: "👑", tier: 3 },
+      { id: "beanie", name: "毛帽", emoji: "🧢", tier: 4 },
+      { id: "flower", name: "小花", emoji: "🌼", tier: 4 },
+      { id: "cap", name: "鴨舌帽", emoji: "🧢", tier: 4 },
+      { id: "party", name: "派對帽", emoji: "🥳", tier: 5 },
+      { id: "antlers", name: "鹿角", emoji: "🦌", tier: 5 },
+      { id: "tophat", name: "紳士帽", emoji: "🎩", tier: 6 },
+      { id: "halo", name: "光環", emoji: "😇", tier: 7 },
+      { id: "starcrown", name: "星辰皇冠", emoji: "👑", tier: 8, limited: true, unlockStreak: 7 }
     ],
     eyes: [
-      { id: "glasses", name: "圓眼鏡", emoji: "👓", price: 0 },
-      { id: "star", name: "星星眼鏡", emoji: "🤩", price: 25 },
-      { id: "heart", name: "愛心墨鏡", emoji: "😍", price: 30 },
-      { id: "shades", name: "太陽眼鏡", emoji: "😎", price: 30 },
-      { id: "mask", name: "華麗面具", emoji: "🎭", price: 45 },
-      { id: "diamond", name: "鑽石眼鏡", emoji: "💎", price: 55 }
+      { id: "glasses", name: "圓眼鏡", emoji: "👓", tier: 1 },
+      { id: "star", name: "星星眼鏡", emoji: "🤩", tier: 2 },
+      { id: "shades", name: "太陽眼鏡", emoji: "😎", tier: 3 },
+      { id: "heart", name: "愛心墨鏡", emoji: "😍", tier: 5 },
+      { id: "mask", name: "華麗面具", emoji: "🎭", tier: 6 },
+      { id: "diamond", name: "鑽石眼鏡", emoji: "💎", tier: 8, limited: true, unlockStreak: 7 }
     ],
     outfit: [
-      { id: "dress", name: "小洋裝", emoji: "👗", price: 0 },
-      { id: "overalls", name: "吊帶褲", emoji: "👖", price: 25 },
-      { id: "scarf", name: "圍巾", emoji: "🧣", price: 20 },
-      { id: "tutu", name: "蓬蓬裙", emoji: "🩰", price: 30 },
-      { id: "cape", name: "英雄斗篷", emoji: "🦸", price: 45 },
-      { id: "gown", name: "公主蓬裙", emoji: "👸", price: 70 },
-      { id: "goddess", name: "星光女神裙", emoji: "🌟", price: 140, limited: true, unlockStreak: 7 }
+      { id: "dress", name: "小洋裝", emoji: "👗", tier: 1 },
+      { id: "scarf", name: "圍巾", emoji: "🧣", tier: 2 },
+      { id: "overalls", name: "吊帶褲", emoji: "👖", tier: 3 },
+      { id: "tutu", name: "蓬蓬裙", emoji: "🩰", tier: 4 },
+      { id: "cape", name: "英雄斗篷", emoji: "🦸", tier: 6 },
+      { id: "gown", name: "公主蓬裙", emoji: "👸", tier: 7 },
+      { id: "goddess", name: "星光女神裙", emoji: "🌟", tier: 8, limited: true, unlockStreak: 7 }
     ],
     back: [
-      { id: "wings", name: "天使翅膀", emoji: "😇", price: 60 },
-      { id: "dragon", name: "龍之翼", emoji: "🐉", price: 70 },
-      { id: "butterfly", name: "蝴蝶翅膀", emoji: "🦋", price: 90, limited: true, unlockStreak: 14 },
-      { id: "phoenix", name: "鳳凰火翼", emoji: "🔥", price: 150, limited: true, unlockStreak: 14 },
-      { id: "rainbowwing", name: "聖光彩翼", emoji: "🌈", price: 220, limited: true, unlockStreak: 14 }
+      { id: "wings", name: "天使翅膀", emoji: "😇", tier: 1 },
+      { id: "dragon", name: "龍之翼", emoji: "🐉", tier: 2 },
+      { id: "butterfly", name: "蝴蝶翅膀", emoji: "🦋", tier: 3 },
+      { id: "phoenix", name: "鳳凰火翼", emoji: "🔥", tier: 7, limited: true, unlockStreak: 14 },
+      { id: "rainbowwing", name: "聖光彩翼", emoji: "🌈", tier: 8, limited: true, unlockStreak: 14 }
     ],
     hand: [
-      { id: "balloon", name: "氣球", emoji: "🎈", price: 0 },
-      { id: "lollipop", name: "棒棒糖", emoji: "🍭", price: 15 },
-      { id: "icecream", name: "冰淇淋", emoji: "🍦", price: 20 },
-      { id: "bouquet", name: "花束", emoji: "💐", price: 25 },
-      { id: "wand", name: "魔法棒", emoji: "🪄", price: 35 },
-      { id: "sword", name: "寶劍", emoji: "⚔️", price: 40 },
-      { id: "teddy", name: "小熊", emoji: "🧸", price: 30 },
-      { id: "scepter", name: "權杖", emoji: "🔮", price: 60 },
-      { id: "genesis", name: "創世法杖", emoji: "🪄", price: 160, limited: true, unlockStreak: 14 }
+      { id: "balloon", name: "氣球", emoji: "🎈", tier: 1 },
+      { id: "lollipop", name: "棒棒糖", emoji: "🍭", tier: 2 },
+      { id: "icecream", name: "冰淇淋", emoji: "🍦", tier: 3 },
+      { id: "bouquet", name: "花束", emoji: "💐", tier: 4 },
+      { id: "teddy", name: "小熊", emoji: "🧸", tier: 4 },
+      { id: "wand", name: "魔法棒", emoji: "🪄", tier: 5 },
+      { id: "sword", name: "寶劍", emoji: "⚔️", tier: 5 },
+      { id: "scepter", name: "權杖", emoji: "🔮", tier: 7 },
+      { id: "genesis", name: "創世法杖", emoji: "🪄", tier: 8, limited: true, unlockStreak: 14 }
     ],
     bg: [
-      { id: "plain", name: "簡約", emoji: "⬜", price: 0 },
-      { id: "rainbow", name: "彩虹", emoji: "🌈", price: 0 },
-      { id: "garden", name: "花園", emoji: "🌷", price: 0 },
-      { id: "forest", name: "森林", emoji: "🌳", price: 30 },
-      { id: "room", name: "房間", emoji: "🏠", price: 30 },
-      { id: "sakura", name: "櫻花樹", emoji: "🌸", price: 40 },
-      { id: "candy", name: "糖果屋", emoji: "🍬", price: 40 },
-      { id: "night", name: "星空夜", emoji: "🌌", price: 40 },
-      { id: "beach", name: "海灘", emoji: "🏖️", price: 40 },
-      { id: "sea", name: "海底", emoji: "🐠", price: 45 },
-      { id: "castle", name: "城堡", emoji: "🏰", price: 50 },
-      { id: "space", name: "太空", emoji: "🚀", price: 50 }
+      { id: "plain", name: "簡約", emoji: "⬜", tier: 1 },
+      { id: "garden", name: "花園", emoji: "🌷", tier: 2 },
+      { id: "rainbow", name: "彩虹", emoji: "🌈", tier: 3 },
+      { id: "forest", name: "森林", emoji: "🌳", tier: 4 },
+      { id: "room", name: "房間", emoji: "🏠", tier: 4 },
+      { id: "sakura", name: "櫻花樹", emoji: "🌸", tier: 5 },
+      { id: "candy", name: "糖果屋", emoji: "🍬", tier: 5 },
+      { id: "night", name: "星空夜", emoji: "🌌", tier: 5 },
+      { id: "beach", name: "海灘", emoji: "🏖️", tier: 5 },
+      { id: "sea", name: "海底", emoji: "🐠", tier: 6 },
+      { id: "castle", name: "城堡", emoji: "🏰", tier: 6 },
+      { id: "space", name: "太空", emoji: "🚀", tier: 7 }
     ],
     fx: [
-      { id: "sakura", name: "落櫻", emoji: "🌸", price: 0 },
-      { id: "bubbles", name: "泡泡", emoji: "🫧", price: 15 },
-      { id: "snow", name: "雪花", emoji: "❄️", price: 20 },
-      { id: "confetti", name: "彩帶", emoji: "🎊", price: 20 },
-      { id: "hearts", name: "愛心雨", emoji: "💕", price: 25 },
-      { id: "stars", name: "星星雨", emoji: "✨", price: 30 },
-      { id: "aurora", name: "極光", emoji: "🌌", price: 45, limited: true, unlockStreak: 7 },
-      { id: "fireworks", name: "煙火", emoji: "🎆", price: 55, limited: true, unlockStreak: 7 }
+      { id: "sakura", name: "落櫻", emoji: "🌸", tier: 1 },
+      { id: "bubbles", name: "泡泡", emoji: "🫧", tier: 2 },
+      { id: "snow", name: "雪花", emoji: "❄️", tier: 3 },
+      { id: "confetti", name: "彩帶", emoji: "🎊", tier: 4 },
+      { id: "hearts", name: "愛心雨", emoji: "💕", tier: 5 },
+      { id: "stars", name: "星星雨", emoji: "✨", tier: 6 },
+      { id: "aurora", name: "極光", emoji: "🌌", tier: 7, limited: true, unlockStreak: 7 },
+      { id: "fireworks", name: "煙火", emoji: "🎆", tier: 8, limited: true, unlockStreak: 7 }
     ]
   };
   function findItem(slot, id) { var l = ITEMS[slot] || []; for (var i = 0; i < l.length; i++) if (l[i].id === id) return l[i]; return null; }
   function isOwned(childKey, it) {
     if (childKey === "self") return true;
-    if (!it || it.price === 0) return true;
+    if (!it || itemPrice(it) === 0) return true;
     if (state.inventory[childKey] && state.inventory[childKey][it.id]) return true;
     if (it.unlockStreak && sleepStreak(childKey) >= it.unlockStreak) return true;
     return false;
@@ -1857,7 +1913,7 @@
   }
   function itemBtn(childKey, slotKey, it, sel) {
     var none = it.id === null, owned = none ? true : isOwned(childKey, it), tag = "";
-    if (!none && !owned) tag = '<span class="price">' + (it.limited ? "🔒 " : "") + fmtMin(it.price) + "</span>";
+    if (!none && !owned) tag = '<span class="price">' + (it.limited ? "🔒 " : "") + fmtMin(itemPrice(it)) + "</span>";
     else if (!none && it.limited) tag = '<span class="price lim">限定</span>';
     var icon = none ? '<span class="wemoji">🚫</span>' : '<span class="wpv">' + itemPreviewSVG(childKey, slotKey, it.id) + '</span>';
     return '<button class="witem' + (sel ? " sel" : "") + (owned ? "" : " locked") + '" data-wslot="' + slotKey + '" data-witem="' + (none ? "" : it.id) + '">' +
@@ -1867,7 +1923,7 @@
     var cp = state.pets[childKey], out = "";
     (ITEMS.species || []).forEach(function (it) {
       var inRoster = !!(cp.roster && cp.roster[it.id]), sel = cp.active === it.id, owned = inRoster || isOwned(childKey, it);
-      var tag = (!inRoster && !owned) ? '<span class="price">' + (it.limited ? "🔒 " : "") + fmtMin(it.price) + "</span>" : (it.limited ? '<span class="price lim">限定</span>' : "");
+      var tag = (!inRoster && !owned) ? '<span class="price">' + (it.limited ? "🔒 " : "") + fmtMin(itemPrice(it)) + "</span>" : (it.limited ? '<span class="price lim">限定</span>' : "");
       var sub = inRoster ? (STAGE_NAME[petStage(cp.roster[it.id].growth)] + (cp.roster[it.id].name ? " · " + escapeHtml(cp.roster[it.id].name) : "")) : "未領養";
       out += '<button class="witem petcard' + (sel ? " sel" : "") + (inRoster || owned ? "" : " locked") + '" data-wslot="species" data-witem="' + it.id + '">' +
         petSVG(childKey, { species: it.id, pet: (cp.roster && cp.roster[it.id]) || defaultPet(), size: 50, showBg: false, mood: false }) +
@@ -1981,10 +2037,10 @@
   }
   function tryBuy(childKey, it) {
     if (it.unlockStreak && sleepStreak(childKey) >= it.unlockStreak) { state.inventory[childKey][it.id] = true; return true; }
-    var bal = balanceOf(childKey);
-    if (bal < it.price) { alert("3C 不夠喔！還差 " + fmtMin(it.price - bal) + "。" + (it.unlockStreak ? "（或連續睡飽 " + it.unlockStreak + " 晚免費解鎖）" : "")); return false; }
-    if (!confirm("用 " + fmtMin(it.price) + " 3C 兌換「" + it.name + "」嗎？")) return false;
-    state.usages.push({ id: uid(), child: childKey, date: todayStr(), minutes: it.price, note: "🛍️ 換購 " + it.name });
+    var bal = balanceOf(childKey), pr = itemPrice(it);
+    if (bal < pr) { alert("3C 不夠喔！還差 " + fmtMin(pr - bal) + "。" + (it.unlockStreak ? "（或連續睡飽 " + it.unlockStreak + " 晚免費解鎖）" : "")); return false; }
+    if (!confirm("用 " + fmtMin(pr) + " 3C 兌換「" + it.name + "」嗎？")) return false;
+    state.usages.push({ id: uid(), child: childKey, date: todayStr(), minutes: pr, note: "🛍️ 換購 " + it.name });
     if (!state.inventory[childKey]) state.inventory[childKey] = {};
     state.inventory[childKey][it.id] = true;
     return true;

--- a/public/3c.html
+++ b/public/3c.html
@@ -1407,8 +1407,8 @@
     { key: "eyes", name: "眼鏡" }, { key: "outfit", name: "衣服" }, { key: "back", name: "背飾" },
     { key: "hand", name: "手持" }, { key: "bg", name: "背景" }, { key: "fx", name: "特效" }
   ];
-  // 8 級制：每個欄位前 3 級免費，第 4 級起越高越貴；price 沒寫就由等級換算
-  var TIER_PRICE = [0, 0, 0, 0, 20, 40, 70, 110, 180];
+  // 8 級制：每個欄位前 3 級免費，第 4 級起越高越貴；price 沒寫就由等級換算（親民曲線、頂級仍低於最貴寵物）
+  var TIER_PRICE = [0, 0, 0, 0, 10, 20, 35, 55, 85];
   function itemPrice(it) { if (!it) return 0; if (typeof it.price === "number") return it.price; return TIER_PRICE[it.tier || 1] || 0; }
   function itemTier(slot, id) { var it = findItem(slot, id); return (it && it.tier) || 1; }
   var ITEMS = {

--- a/public/3c.html
+++ b/public/3c.html
@@ -247,6 +247,8 @@
   .growbar { flex: 1; height: 8px; background: #eee; border-radius: 999px; overflow: hidden; }
   .growbar i { display: block; height: 100%; background: linear-gradient(90deg, #ffd23f, #ff8f1f); border-radius: 999px; transition: width .4s; }
   .growtxt { font-size: .74rem; color: var(--muted); font-weight: 600; white-space: nowrap; }
+  .growsub { font-size: .72rem; color: #19a85e; font-weight: 700; margin: 1px 4px 2px; line-height: 1.3; }
+  .growsub.done { color: var(--muted); }
   .stat .bar i.lowbar { background: linear-gradient(90deg, #ff8f1f, #e23b54); }
   .stat .bar i.bl1 { background: linear-gradient(90deg, #ffd23f, #ffb15f); }
   .stat .bar i.bl2 { background: linear-gradient(90deg, #ff9a3d, #ff7a1a); }
@@ -275,6 +277,9 @@
   .stat .bar { position: relative; height: 10px; background: #eee; border-radius: 999px; overflow: hidden; }
   .stat .bar i { display: block; height: 100%; background: linear-gradient(90deg,#7c5cff,#ff5fa2); border-radius: 999px; transition: width .45s ease; }
   .stat .bar .caremark { position: absolute; top: 0; bottom: 0; width: 2px; margin-left: -1px; background: #4a2f5e; opacity: .5; z-index: 1; }
+  .stat .bar.cangrow { box-shadow: inset 0 0 0 1.5px #9be7bd; }
+  .stat .bar .caremark.active { width: 3px; opacity: 1; background: #19a85e; box-shadow: 0 0 0 1px #fff, 0 0 6px #54d98c; animation: caremarkpulse 1.1s ease-in-out infinite; }
+  @keyframes caremarkpulse { 0%, 100% { box-shadow: 0 0 0 1px #fff, 0 0 4px #54d98c; } 50% { box-shadow: 0 0 0 1px #fff, 0 0 10px #54d98c; } }
   .scene-on .petart { animation: none !important; }
   .scene-on .petart svg { filter: drop-shadow(0 8px 12px rgba(0,0,0,.14)); }
   .scenebar { text-align: center; font-weight: 800; font-size: .92rem; color: var(--brand); margin: 6px 0 2px; padding: 7px 10px; border-radius: 12px; background: #efeaff; }
@@ -1544,8 +1549,13 @@
     if (p.sickDay !== day) { p.sickDay = day; if (Math.random() < 0.05) p.sick = true; }
   }
   var petExpr = "auto", exprTimer = null, petFlash = null;
-  var GROWTH_PER_CARE = 2, DAILY_GROWTH_CAP = 12, NEED_LOW = 90, CARE_MARK = 60;
+  var GROWTH_PER_CARE = 2, DAILY_GROWTH_CAP = 18, NEED_LOW = 90, CARE_MARK = 60;
   var sceneRunning = false, sceneTimer = null, sceneBefore = 80;
+  // 今天還能「長大」幾次（每次照顧低於線的需求 +GROWTH_PER_CARE，到 DAILY_GROWTH_CAP 為止）
+  function growLeftToday(p) {
+    var used = (p.growthDay === todayStr()) ? (p.growthToday || 0) : 0;
+    return Math.max(0, Math.ceil((DAILY_GROWTH_CAP - used) / GROWTH_PER_CARE));
+  }
   var SCENE = { steps: 13, ms: 380, happyFrom: 10 };
   var SCENE_VERB = { feed: "餵食中…大口吃！", drink: "喝水中…咕嚕咕嚕", bath: "洗香香…搓搓搓", toilet: "上廁所…噓～", play: "玩耍中…接球！", sleep: "哄睡中…晚安", pat: "摸摸頭…秀秀", doctor: "看醫生中…乖乖打針" };
 
@@ -1773,15 +1783,23 @@
     // 真實連鎖反應：玩完會髒會餓會渴、洗完澡想睡、吃喝完想上廁所…
     if (a.side) Object.keys(a.side).forEach(function (k) { p.needs[k] = Math.max(8, Math.min(100, (p.needs[k] == null ? 80 : p.needs[k]) + a.side[k])); });
     petFlash = null;
-    if (key !== "doctor" && before < CARE_MARK) {
+    if (key !== "doctor") {
       var day = todayStr();
       if (p.growthDay !== day) { p.growthDay = day; p.growthToday = 0; }
-      if ((p.growthToday || 0) < DAILY_GROWTH_CAP) {
+      if (before >= CARE_MARK) {
+        // 照顧的這一項本來就高於那條線 → 不算成長。以前完全沒提示，最容易讓人以為「壞掉」
+        var nm = NEED_MAP[a.need] ? NEED_MAP[a.need].name : "這項";
+        petFlash = { cls: "info", text: "💛 " + nm + "還很充足～等它降到線以下再照顧，就會長大囉 🌱" };
+      } else if ((p.growthToday || 0) >= DAILY_GROWTH_CAP) {
+        petFlash = { cls: "info", text: "今天已經長大很多囉，明天再來陪它就會繼續長大 🌙" };
+      } else {
         var add = Math.min(GROWTH_PER_CARE, DAILY_GROWTH_CAP - (p.growthToday || 0));
         var was = petStage(p.growth || 0);
         p.growth = Math.min(160, (p.growth || 0) + add); p.growthToday = (p.growthToday || 0) + add;
+        var left = growLeftToday(p);
         if (petStage(p.growth) > was) petFlash = { cls: "grow", text: "🎉 長大了！變成「" + STAGE_NAME[petStage(p.growth)] + "」囉！" };
-      } else petFlash = { cls: "info", text: "今天已經長大很多囉，明天再來陪它 🌙" };
+        else petFlash = { cls: "grow", text: "💛 又長大一點點！" + (left > 0 ? "（今天還能長大 " + left + " 次）" : "（今天的成長到頂囉 🌙）") };
+      }
     }
     if (!petFlash) petFlash = { cls: "info", text: a.note || "它現在心情更好了 😊" };
     save();
@@ -1889,7 +1907,8 @@
   function needsHTML(p) {
     return '<div class="stats">' + NEEDS.map(function (n) {
       var v = Math.round(p.needs[n.key] == null ? 80 : p.needs[n.key]); var lv = needTier(v);
-      return '<div class="stat"><span class="sl">' + n.emoji + " " + n.name + '</span><div class="bar"><i class="bl' + lv + '" style="width:' + v + '%"></i><span class="caremark" style="left:' + CARE_MARK + '%" title="低於這條線時照顧，會長大一次"></span></div></div>';
+      var below = v < CARE_MARK;   // 低於線 → 現在照顧這項會長大，把線點亮提示
+      return '<div class="stat"><span class="sl">' + n.emoji + " " + n.name + '</span><div class="bar' + (below ? ' cangrow' : '') + '"><i class="bl' + lv + '" style="width:' + v + '%"></i><span class="caremark' + (below ? ' active' : '') + '" style="left:' + CARE_MARK + '%" title="' + (below ? '現在低於線囉！照顧這項就會長大 🌱' : '低於這條線時照顧，才會長大一次') + '"></span></div></div>';
     }).join("") + "</div>";
   }
   function petStatusLine(p) {
@@ -1900,9 +1919,13 @@
   function petAgeHTML(p) {
     var g = p.growth || 0, st = petStage(g), nx = nextStageAt(g), prev = [0, 15, 40, 80][st];
     var pct = nx ? Math.round((g - prev) / ((nx || 80) - prev) * 100) : 100;
+    var left = growLeftToday(p);
+    var sub = !nx ? "" : (left > 0
+      ? '<div class="growsub">🌱 今天還能長大 <b>' + left + '</b> 次（照顧低於線的需求就會長大）</div>'
+      : '<div class="growsub done">🌙 今天已經長大滿了，明天再來照顧就會繼續長大</div>');
     return '<div class="petage"><span class="stagebadge s' + st + '">' + STAGE_NAME[st] + '</span>' +
       '<div class="growbar"><i style="width:' + pct + '%"></i></div>' +
-      '<span class="growtxt">' + (nx ? "再照顧 " + Math.ceil((nx - g) / 2) + " 次長大" : "已長大成年 🎉") + "</span></div>";
+      '<span class="growtxt">' + (nx ? "再照顧 " + Math.ceil((nx - g) / GROWTH_PER_CARE) + " 次長大" : "已長大成年 🎉") + "</span></div>" + sub;
   }
   // 換裝小舖的圖示＝直接畫出「穿上這件後的樣子」，所見即所得（不再用 emoji，避免和實際不一樣）
   function itemPreviewSVG(childKey, slotKey, itemId) {


### PR DESCRIPTION
## 這次做了什麼

把**所有配件**（含原本既有的）重新整理成 **8 級制**，並讓每個配件都依等級套用分級特效。重點是：**特效再華麗也永遠不會擋到臉**。

### 分級與價格
- 每個欄位（顏色／頭飾／眼鏡／衣服／背飾／手持／背景／特效）都分成 tier 1–8。
- **每欄位前 3 級免費**，第 4 級起要付費，**越後面兌換時間越多**（`TIER_PRICE = [0,0,0,0,20,40,70,110,180]`）。
- 寵物本體（species）維持原本的價格不變。

### 分級特效（原有配件也一起升級，不再只有新配件有特效）
- **背光層 `tierAura`**：柔光暈＋放射光畫在角色**後方、半透明**，純粹當光暈。
- **前景層 `tierSparkle`**：環繞星＋閃粉畫在最上層，但用 **`inFace()` 臉部保留區**自動略過會蓋到五官的粒子 → **不擋臉**。
- **`tierScale`**：等級越高、配件本體尺寸略放大，當主角。
- 等級越高越浮誇：t5 加光暈 → t6 放射光 → t7 環繞星 → t8 最華麗「哇」。

### 既有使用者保障（不會把人家本來有的拿走）
- 已購買的配件本來就在庫存，**永遠保留**。
- 原本免費、這次改付費的只有顏色「天藍」一項；用 `settings.gf1` 標記**一次性補發**給更新前就有資料的使用者，**全新使用者不發放**（標記會隨存檔與雲端同步持久化）。

### 版本
- `v2.4 · 八級配件版`

## 驗證
- `node --check` 通過。
- VM + DOM stub 跑真實程式碼，匯出內部函式後用 `@resvg/resvg-js` 實際渲染 PNG 檢視：
  - 確認 t1→t8 特效逐級遞增、頂級「哇」感。
  - 確認**單件與滿裝（全部 t8）臉部都清晰不被擋**。
- 25 項邏輯測試全過：補發遷移（新舊使用者）、價格、`isOwned`、八個欄位 wardrobe 皆可正常渲染。

## 注意
- CSS 版面（重疊類）無法用 resvg 驗證，建議實機再看一眼換裝小舖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k)_