### PR TITLE
移除 UI 版本字串（畫面清爽）

### DIFF
--- a/public/3c.html
+++ b/public/3c.html
@@ -357,7 +357,6 @@
   <header class="top">
     <h1 id="appTitle"><i class="emo">⭐</i> Mia &amp; Tia 的 3C 時間銀行</h1>
     <div class="rules" id="rulesLine"></div>
-    <span class="appver" id="appVer"></span>
   </header>
 
   <div class="tabbar">
@@ -524,7 +523,6 @@
 
   <footer>
     睡飽飽，換 3C ⭐ · 24 小時制 · 睡好賺 3C，3C 可看螢幕、也能幫小怪獸買裝扮 🐾
-    <div class="appver-foot" id="appVerFoot"></div>
   </footer>
 </div>
 
@@ -532,7 +530,7 @@
 (function () {
   "use strict";
 
-  var APP_VER = "v2.5 · 盲盒限定色 · 成長造型 · 2026-06-21";
+  var APP_VER = "v2.5 · 盲盒限定色 · 成長造型 · 2026-06-21";   // 內部版本記錄；依使用者要求不再顯示於 UI（頁尾／睡眠頁橫幅／狀態圖鑑）
   var STORAGE_KEY = "mt-3c-panel-v1";
   var HISTORY_KEY = "mt-3c-history-v1";
   var HISTORY_MAX = 30;
@@ -2407,7 +2405,7 @@
     if (!host) { host = document.createElement("div"); host.id = "stategallery"; document.body.appendChild(host); }
     var TIERS = [58, 38, 14];
     var h = '<div class="gwrap"><button class="gclose">✕ 關閉</button>' +
-      "<h1>🎭 寵物狀態圖鑑</h1><p class=\"ghint\">目前版本：" + APP_VER + "。需求掉到剩約 2/3 就開始有表情，越低變化越明顯。</p>";
+      "<h1>🎭 寵物狀態圖鑑</h1><p class=\"ghint\">需求掉到剩約 2/3 就開始有表情，越低變化越明顯。</p>";
     h += '<div class="ggrid">' + galleryCard("😊 健康", "", null) + "</div>";
     NEEDS.forEach(function (n) {
       h += "<h3>" + n.emoji + " " + n.name + "</h3><div class=\"ggrid\">";
@@ -2436,7 +2434,6 @@
   $("profileSel").value = state.profile;
   if (lockedChild()) petWho = lockedChild();
   applyProfile();
-  $("appVer").textContent = APP_VER; $("appVerFoot").textContent = "版本 " + APP_VER;
   fillSettings(); updateForm(); render(); showTab("sleep");
   refreshLockSection(); applyLock(); renderHistory();
   if (window.matchMedia) { try { window.matchMedia("(min-width:1024px)").addEventListener("change", function () { render(); }); } catch (e) {} }


### PR DESCRIPTION
依使用者要求，把顯示用的版本字串從 UI 完全拿掉（覺得太醜）：

- 睡眠頁橫幅的版本牌
- 頁尾「版本 v2.5 · …」
- 狀態圖鑑的「目前版本：…」

`APP_VER` 變數保留為**內部版本記錄**，不再渲染到任何畫面。畫面更乾淨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k)_