### PR TITLE
版本號改右下角小角落顯示

### DIFF
--- a/public/3c.html
+++ b/public/3c.html
@@ -45,8 +45,7 @@
   header.top h1 .emo { font-style: normal; }
   header.top .rules { margin-top: 8px; font-size: .9rem; opacity: .95; background: rgba(255,255,255,.16); padding: 8px 12px; border-radius: 10px; }
   header.top .rules b { font-weight: 700; }
-  header.top .appver { display: inline-block; margin-top: 8px; background: rgba(255,255,255,.2); color: #fff; font-size: .72rem; font-weight: 800; padding: 4px 11px; border-radius: 999px; letter-spacing: .3px; }
-  footer .appver-foot { margin-top: 6px; font-size: .74rem; opacity: .8; }
+  #verTag { position: fixed; right: 7px; bottom: 6px; z-index: 6; font-size: 10px; line-height: 1; font-weight: 700; color: rgba(255,255,255,.9); background: rgba(50,45,70,.38); padding: 2px 7px; border-radius: 8px; letter-spacing: .3px; pointer-events: none; -webkit-backdrop-filter: blur(2px); backdrop-filter: blur(2px); }
 
   /* Tabs */
   .tabbar { display: flex; gap: 8px; margin: 16px 0 0; }
@@ -525,12 +524,13 @@
     睡飽飽，換 3C ⭐ · 24 小時制 · 睡好賺 3C，3C 可看螢幕、也能幫小怪獸買裝扮 🐾
   </footer>
 </div>
+<div id="verTag"></div>
 
 <script>
 (function () {
   "use strict";
 
-  var APP_VER = "v2.5 · 盲盒限定色 · 成長造型 · 2026-06-21";   // 內部版本記錄；依使用者要求不再顯示於 UI（頁尾／睡眠頁橫幅／狀態圖鑑）
+  var APP_VER = "v2.6 · 2026-06-21";   // 內部完整版本；UI 只在右下角小角落顯示版本號（APP_VER 第一段）
   var STORAGE_KEY = "mt-3c-panel-v1";
   var HISTORY_KEY = "mt-3c-history-v1";
   var HISTORY_MAX = 30;
@@ -2434,6 +2434,7 @@
   $("profileSel").value = state.profile;
   if (lockedChild()) petWho = lockedChild();
   applyProfile();
+  $("verTag").textContent = APP_VER.split(" · ")[0];
   fillSettings(); updateForm(); render(); showTab("sleep");
   refreshLockSection(); applyLock(); renderHistory();
   if (window.matchMedia) { try { window.matchMedia("(min-width:1024px)").addEventListener("change", function () { render(); }); } catch (e) {} }


### PR DESCRIPTION
版本號改成**右下角低調小角落**顯示（不再用睡眠頁橫幅大牌子＋頁尾整行）：

- 右下角一個半透明小標籤，只顯示版本號（如 `v2.6`）
- `pointer-events:none`、不擋操作、深淺背景都看得清楚
- `APP_VER` 內部仍保留完整版本字串，方便日後追蹤

這次也把 `APP_VER` 升到 `v2.6`，部署後你右下角看到 **v2.6** 就代表正式版已更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k)_