### PR TITLE
HTML 一律 no-cache（解決舊頁面被快取、更新不生效）

### DIFF
--- a/public/3c.html
+++ b/public/3c.html
@@ -530,7 +530,7 @@
 (function () {
   "use strict";
 
-  var APP_VER = "v2.6 · 2026-06-21";   // 內部完整版本；UI 只在右下角小角落顯示版本號（APP_VER 第一段）
+  var APP_VER = "v2.7 · 2026-06-21";   // 內部完整版本；UI 只在右下角小角落顯示版本號（APP_VER 第一段）
   var STORAGE_KEY = "mt-3c-panel-v1";
   var HISTORY_KEY = "mt-3c-history-v1";
   var HISTORY_MAX = 30;

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,20 @@ export default {
 
     // Handle static assets (frontend)
     if (url.pathname === "/" || !url.pathname.startsWith("/api/")) {
-      return env.ASSETS.fetch(request);
+      const res = await env.ASSETS.fetch(request);
+      // Always revalidate HTML so app updates show up immediately after a deploy
+      // (otherwise the browser / iOS home-screen webclip keeps serving a stale page).
+      const ct = res.headers.get("content-type") || "";
+      if (ct.includes("text/html")) {
+        const headers = new Headers(res.headers);
+        headers.set("Cache-Control", "no-cache, no-store, must-revalidate");
+        return new Response(res.body, {
+          status: res.status,
+          statusText: res.statusText,
+          headers,
+        });
+      }
+      return res;
     }
 
     // Cross-device sync for the Mia & Tia 3C panel (stored in a Durable Object).


### PR DESCRIPTION
## 根因修正：HTML 一律 no-cache

你看到「叫我刪的字還在」，其實正式版的程式碼**早就把橫幅＋頁尾的版本字串刪掉了**（我直接驗證過 `main` 上部署的檔案，只剩右下角小角落的版本號）。問題是手機把**舊頁面快取住**了——之前 Worker 沒有設快取標頭，iOS 加到主畫面的 webclip 會一直顯示舊版。

這個 PR 讓 Worker 對所有 `text/html` 回應加上 `Cache-Control: no-cache, no-store, must-revalidate`，之後每次更新到正式版，**重整就會立刻看到最新內容**，不會再卡舊頁面。

順手把 `APP_VER` 升到 `v2.7`，清一次快取後右下角會變 **v2.7**，就代表吃到新版了。

- `src/index.ts`：包一層 ASSETS 回應，HTML 加 no-cache 標頭（其他靜態檔不受影響）
- `tsc --noEmit` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k)_