### PR TITLE
限時特價全裝置一致 ＋ 試穿改手遊風彈窗 v3.1

### DIFF
--- a/public/3c.html
+++ b/public/3c.html
@@ -304,7 +304,6 @@
   .witem .price { font-size: .68rem; font-weight: 800; color: var(--brand); background: #eceaff; border-radius: 999px; padding: 1px 6px; }
   .witem .price.lim { color: #fff; background: var(--warn); }
   .witem.sel { border-color: var(--brand); box-shadow: 0 0 0 3px #eceaff; }
-  .witem.pv { border-color: #ff5d73; box-shadow: 0 0 0 3px #ffe3ee; }
   .witem.locked .wemoji { filter: grayscale(.35); opacity: .85; }
 
   /* 限時折扣 */
@@ -343,19 +342,35 @@
   #dealmodal .dm-price s { color: var(--muted); font-weight: 600; margin-right: 5px; }
   #dealmodal .dm-off { flex: 0 0 auto; color: #fff; background: linear-gradient(135deg,#ff6fae,#ff4d6d); font-weight: 800; font-size: .78rem; border-radius: 999px; padding: 3px 9px; }
 
-  /* 試穿預覽：底部購買列 */
-  .petart.previewing { animation: pvBob 1.8s ease-in-out infinite; }
-  @keyframes pvBob { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-5px); } }
-  @media (prefers-reduced-motion: reduce) { .petart.previewing { animation: none; } }
-  #previewBar { position: fixed; left: 50%; bottom: 0; transform: translateX(-50%); z-index: 40; width: 100%; max-width: 460px; display: flex; align-items: center; gap: 8px; padding: 8px 10px calc(8px + env(safe-area-inset-bottom)); background: rgba(255,255,255,.97); box-shadow: 0 -6px 18px rgba(0,0,0,.16); border-radius: 16px 16px 0 0; -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px); }
-  #previewBar .pv-ic { width: 38px; height: 38px; flex: 0 0 38px; display: grid; place-items: center; }
-  #previewBar .pv-ic svg { width: 38px; height: 38px; display: block; }
-  #previewBar .pv-txt { flex: 1 1 auto; min-width: 0; font-size: .82rem; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  #previewBar .pv-txt b { color: #2b2540; margin-left: 3px; }
-  #previewBar .pv-cancel { flex: 0 0 auto; border: none; background: #f0eef7; color: var(--muted); width: 32px; height: 32px; border-radius: 999px; font-size: 1rem; cursor: pointer; }
-  #previewBar .pv-buy { flex: 0 0 auto; border: none; background: linear-gradient(135deg,#ff6fae,#ff4d6d); color: #fff; font-weight: 800; font-size: .86rem; padding: 9px 14px; border-radius: 999px; cursor: pointer; display: inline-flex; align-items: center; gap: 5px; box-shadow: 0 4px 10px rgba(255,77,109,.3); }
-  #previewBar .pv-buy s { opacity: .8; font-weight: 600; }
-  #previewBar .pv-buy .pv-off { font-style: normal; font-size: .66rem; background: rgba(255,255,255,.28); border-radius: 999px; padding: 0 5px; }
+  /* 商品試穿彈窗（手遊風・置中卡片） */
+  #dealmodal .dm-card.dm-center { bottom: auto; top: 50%; transform: translate(-50%, -50%); width: calc(100% - 36px); max-width: 360px; border-radius: 24px; padding: 20px 18px 18px; text-align: center; overflow: hidden; animation: dmPop .26s cubic-bezier(.2,1.1,.4,1); }
+  @keyframes dmPop { from { transform: translate(-50%, -46%) scale(.9); opacity: 0; } to { transform: translate(-50%, -50%) scale(1); opacity: 1; } }
+  .im-x { position: absolute; right: 12px; top: 12px; z-index: 3; border: none; background: rgba(255,255,255,.65); color: #6b6680; width: 30px; height: 30px; border-radius: 999px; font-size: 1rem; cursor: pointer; }
+  .im-stage { position: relative; margin: -20px -18px 12px; height: 198px; display: grid; place-items: center; background: radial-gradient(120% 100% at 50% 18%, #fff5fb 0%, #ffe9f4 45%, #ece6ff 100%); overflow: hidden; }
+  .im-stage.lim { background: radial-gradient(120% 100% at 50% 18%, #fff8e8 0%, #ffeec0 42%, #ffd6f0 100%); }
+  .im-stage.lim::before { content: ""; position: absolute; inset: 0; pointer-events: none; background: radial-gradient(2px 2px at 20% 30%, #fff, transparent), radial-gradient(2px 2px at 80% 26%, #fff, transparent), radial-gradient(2px 2px at 66% 62%, #fff, transparent), radial-gradient(2px 2px at 32% 70%, #fff, transparent), radial-gradient(2px 2px at 50% 18%, #fff, transparent); animation: imSpark 2.2s ease-in-out infinite; }
+  @keyframes imSpark { 0%,100% { opacity: .25; } 50% { opacity: .95; } }
+  .im-spot { position: absolute; bottom: 16px; left: 50%; transform: translateX(-50%); width: 132px; height: 26px; border-radius: 50%; background: radial-gradient(closest-side, rgba(110,80,160,.3), rgba(110,80,160,0)); }
+  .im-pet { position: relative; filter: drop-shadow(0 8px 12px rgba(0,0,0,.16)); animation: imFloat 3s ease-in-out infinite; }
+  .im-pet svg { width: 172px; height: 172px; display: block; }
+  @keyframes imFloat { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-6px); } }
+  @media (prefers-reduced-motion: reduce) { .im-pet, .im-stage.lim::before { animation: none; } }
+  .im-head { display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: wrap; }
+  .im-title { font-size: 1.15rem; font-weight: 900; color: #2b2540; }
+  .im-rar { font-size: .68rem; font-weight: 800; color: #6b6680; background: #efecf7; border-radius: 999px; padding: 2px 8px; }
+  .im-rar.lim { color: #fff; background: linear-gradient(135deg,#ffb01f,#ff7a59); }
+  .im-pricerow { display: flex; align-items: baseline; justify-content: center; gap: 6px; margin-top: 10px; }
+  .im-old { color: #b9b4c9; text-decoration: line-through; font-weight: 700; font-size: .95rem; }
+  .im-new { color: var(--brand); font-weight: 900; font-size: 1.7rem; line-height: 1; }
+  .im-unit { color: var(--brand); font-weight: 800; font-size: .9rem; }
+  .im-off { color: #fff; background: linear-gradient(135deg,#ff6fae,#ff4d6d); font-weight: 800; font-size: .72rem; border-radius: 999px; padding: 2px 7px; align-self: center; }
+  .im-timer { margin-top: 8px; font-size: .82rem; color: #d6336c; font-weight: 700; }
+  .im-timer b { font-variant-numeric: tabular-nums; }
+  .im-bal { margin-top: 10px; font-size: .82rem; color: var(--muted); }
+  .im-bal b { color: #2b2540; }
+  .im-buy { width: 100%; margin-top: 14px; border: none; border-radius: 14px; padding: 13px; font-size: 1.02rem; font-weight: 900; color: #fff; background: linear-gradient(135deg,#7c6cff,#9b6bff); cursor: pointer; box-shadow: 0 8px 18px rgba(124,108,255,.35); }
+  .im-buy.off { background: #d9d6e4; color: #fff; box-shadow: none; cursor: not-allowed; }
+  .im-skip { width: 100%; margin-top: 8px; border: none; background: none; color: var(--muted); font-size: .88rem; font-weight: 700; padding: 8px; cursor: pointer; }
 
   /* mode bar */
   .modebar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 12px; font-size: .86rem; color: var(--muted); }
@@ -577,7 +592,7 @@
 (function () {
   "use strict";
 
-  var APP_VER = "v3.0 · 2026-06-21";   // 內部完整版本；UI 只在右下角小角落顯示版本號（APP_VER 第一段）
+  var APP_VER = "v3.1 · 2026-06-22";   // 內部完整版本；UI 只在右下角小角落顯示版本號（APP_VER 第一段）
   var STORAGE_KEY = "mt-3c-panel-v1";
   var HISTORY_KEY = "mt-3c-history-v1";
   var HISTORY_MAX = 30;
@@ -1613,7 +1628,7 @@
   var deals = (function () {
     try { var r = localStorage.getItem(DEALS_KEY), d = r ? JSON.parse(r) : null; return (d && typeof d === "object") ? d : {}; } catch (e) { return {}; }
   })();
-  var dealTimer = null;
+  var dealTimer = null, itemModalRef = null, lastSaleCycle = -1;
   function saveDeals() { try { localStorage.setItem(DEALS_KEY, JSON.stringify(deals)); } catch (e) { } }
   function randPct() { return DEAL_PCTS[Math.floor(Math.random() * DEAL_PCTS.length)]; }
   function dealPrice(base, pct) { return Math.max(1, Math.round(base * (100 - pct) / 100)); }
@@ -1622,7 +1637,24 @@
     Object.keys(ITEMS).forEach(function (slot) { ITEMS[slot].forEach(function (it) { if (itemPrice(it) > 0) out.push({ slot: slot, id: it.id }); }); });
     return out;
   }
-  function saleActive() { var s = deals.sale; return (s && s.endAt > Date.now()) ? s : null; }
+  // 「常態限時特價」：完全用時間推導（固定亂數種子），所以每台裝置、每次開都一模一樣；
+  // 一檔接一檔不間斷，每檔 3~5 天，倒數歸零就換下一檔（單檔期間商品固定不變）。
+  var SALE_EPOCH = Date.UTC(2026, 0, 1);
+  function hashSeed(n) { var x = Math.sin(n * 12.9898 + 78.233) * 43758.5453; return x - Math.floor(x); }
+  function saleCycleAt(now) {
+    var t = SALE_EPOCH, i = 0;
+    for (; i < 100000; i++) { var len = (3 + Math.floor(hashSeed(i * 2 + 1) * 3)) * DAY_MS; if (t + len > now) return { index: i, start: t, len: len }; t += len; }
+    return { index: i, start: t, len: 4 * DAY_MS };
+  }
+  function computeSale() {
+    var pool = pricedItems(); if (!pool.length) return null;
+    var cyc = saleCycleAt(Date.now());
+    var pick = pool[Math.floor(hashSeed(cyc.index * 2) * pool.length) % pool.length];
+    var pct = DEAL_PCTS[Math.floor(hashSeed(cyc.index * 7 + 3) * DEAL_PCTS.length) % DEAL_PCTS.length];
+    return { slot: pick.slot, id: pick.id, pct: pct, startAt: cyc.start, endAt: cyc.start + cyc.len, cycle: cyc.index };
+  }
+  var _saleCache = { at: -1, val: null };
+  function saleActive() { var now = Date.now(); if (now - _saleCache.at >= 1000) { _saleCache.at = now; _saleCache.val = computeSale(); } return _saleCache.val; }
   function flashActive(childKey) { var f = deals.flash; return (f && f.child === childKey && f.endAt > Date.now()) ? f : null; }
   // 某童某件物品目前的折扣 %（特價與快閃取較大者），沒折扣回 0
   function discountFor(childKey, slot, id) {
@@ -1641,21 +1673,14 @@
   }
   function fmtCountdown(ms) {
     if (ms < 0) ms = 0;
-    var s = Math.floor(ms / 1000), h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60);
+    var s = Math.floor(ms / 1000), d = Math.floor(s / 86400), h = Math.floor((s % 86400) / 3600), m = Math.floor((s % 3600) / 60);
+    if (d > 0) return d + "天 " + pad2(h) + ":" + pad2(m) + ":" + pad2(s % 60);
     return h + ":" + pad2(m) + ":" + pad2(s % 60);
   }
   function dealItemPreview(childKey, slot, id) {
     if (slot === "species") return petSVG(childKey, { species: id, pet: defaultPet(), size: 48, showBg: false, mood: false });
     return itemPreviewSVG(childKey, slot, id);
   }
-  function rollSale() {
-    var pool = pricedItems(); if (!pool.length) return;
-    var pick = pool[Math.floor(Math.random() * pool.length)], now = Date.now();
-    deals.sale = { slot: pick.slot, id: pick.id, pct: randPct(), startAt: now, endAt: now + DAY_MS, seen: false };
-    deals.nextSaleAt = now + Math.round((3 + Math.random() * 2) * DAY_MS);   // 下一檔 3～5 天後
-    saveDeals();
-  }
-  function markSaleSeen() { if (deals.sale) { deals.sale.seen = true; saveDeals(); } }
   // 主動付費購買後，挑「現在剩餘 3C 折扣後買得起、且還沒擁有」的物品，最多 3 件，限時 3 小時
   function triggerFlash(childKey) {
     if (childKey === "self" || flashActive(childKey)) return null;
@@ -1676,32 +1701,58 @@
     if (childKey === "self") return "";
     var s = saleActive(); if (!s) return "";
     var it = findItem(s.slot, s.id); if (!it || isOwned(childKey, it)) return "";
-    return '<button class="dealalert" data-dealslot="' + s.slot + '" aria-label="限時特價" title="限時特價 -' + s.pct + "%「" + escapeHtml(it.name) + '」">' +
+    return '<button class="dealalert" data-saleopen="1" aria-label="限時特價" title="限時特價 -' + s.pct + "%「" + escapeHtml(it.name) + '」">' +
       '<span class="da-ic">' + dealItemPreview(childKey, s.slot, s.id) + '<i class="da-off">-' + s.pct + "%</i></span>" +
       '<span class="da-time" data-countdown="' + s.endAt + '">' + fmtCountdown(s.endAt - Date.now()) + "</span>" +
       "</button>";
   }
-  function dealModal(html) {
+  function dealModal(html, centered) {
     var host = document.getElementById("dealmodal");
     if (!host) { host = document.createElement("div"); host.id = "dealmodal"; document.body.appendChild(host); }
-    host.innerHTML = '<div class="dm-back" data-dmclose="1"></div><div class="dm-card">' + html + "</div>";
+    host.className = centered ? "centered" : "";
+    host.innerHTML = '<div class="dm-back" data-dmclose="1"></div><div class="dm-card' + (centered ? " dm-center" : "") + '">' + html + "</div>";
     host.style.display = "block";
     return host;
   }
-  function closeDealModal() { var h = document.getElementById("dealmodal"); if (h) { h.style.display = "none"; h.innerHTML = ""; } }
-  function showSalePopup(s) {
-    if (!s) return; var it = findItem(s.slot, s.id); if (!it) return;
-    var base = itemPrice(it);
-    var host = dealModal('<button class="dm-x" data-dmclose="1">✕</button>' +
-      '<div class="dm-h">⏰ 新的限時特價！</div>' +
-      '<div class="dm-bigpv">' + dealItemPreview(petWho, s.slot, s.id) + "</div>" +
-      '<div class="dm-sub"><b>' + escapeHtml(it.name) + "</b> 現在 <b>-" + s.pct + "%</b>：<s>" + fmtMin(base) + "</s> → <b>" + fmtMin(dealPrice(base, s.pct)) + ' 3C</b><br>倒數 <b id="flashCountdown" data-end="' + s.endAt + '">' + fmtCountdown(s.endAt - Date.now()) + "</b>（24 小時內買最划算）</div>" +
-      '<button class="btn" data-dealgo="' + s.slot + '" style="width:100%">去小舖看看 🛍️</button>' +
-      '<button class="btn ghost" data-dmclose="1" style="width:100%;margin-top:8px">知道了</button>');
+  function closeDealModal() { var h = document.getElementById("dealmodal"); if (h) { h.style.display = "none"; h.innerHTML = ""; h.className = ""; } }
+  // 商品試穿彈窗（手遊風）：把商品穿到角色身上預覽，喜歡再買
+  function openItemModal(childKey, slot, id) {
+    if (childKey === "self") { chooseItem(childKey, slot, id); return; }   // self 全免費 → 直接穿
+    var it = findItem(slot, id); if (!it) return;
+    var pct = discountFor(childKey, slot, id), base = itemPrice(it), price = pct ? dealPrice(base, pct) : base;
+    var bal = balanceOf(childKey), afford = bal >= price;
+    var p = activePet(childKey), rp = previewClone(p), species = state.pets[childKey].active;
+    if (slot === "species") species = id; else if (slot === "color") rp.color = id; else rp.wear[slot] = id;
+    var sale = saleActive(), onSale = !!(sale && sale.slot === slot && sale.id === id);
+    var rar = it.limited ? '<span class="im-rar lim">✦ 限定款</span>' : '<span class="im-rar">一般款</span>';
+    var priceRow = '<div class="im-pricerow">' + (pct ? '<span class="im-old">' + fmtMin(base) + "</span>" : "") +
+      '<span class="im-new">' + fmtMin(price) + '</span><span class="im-unit">3C</span>' + (pct ? '<span class="im-off">-' + pct + "%</span>" : "") + "</div>";
+    var timer = onSale ? '<div class="im-timer">⏰ 限時特價　倒數 <b data-countdown="' + sale.endAt + '">' + fmtCountdown(sale.endAt - Date.now()) + "</b></div>" : "";
+    var buy = afford
+      ? '<button class="im-buy" data-imbuy="1">購買　' + fmtMin(price) + " 3C</button>"
+      : '<button class="im-buy off" disabled>3C 不夠，還差 ' + fmtMin(price - bal) + "</button>";
+    itemModalRef = { childKey: childKey, slot: slot, id: id };
+    var host = dealModal('<button class="im-x" data-dmclose="1">✕</button>' +
+      '<div class="im-stage' + (it.limited ? " lim" : "") + '"><div class="im-spot"></div><div class="im-pet">' + petSVG(childKey, { pet: rp, species: species, size: 172, expr: "normal", showBg: false }) + "</div></div>" +
+      '<div class="im-head"><span class="im-title">' + escapeHtml(it.name) + "</span>" + rar + "</div>" +
+      priceRow + timer +
+      '<div class="im-bal">👛 ' + escapeHtml(childOf(childKey).name) + " 的 3C 存摺：<b>" + fmtMin(bal) + "</b></div>" +
+      buy +
+      '<button class="im-skip" data-dmclose="1">先逛逛</button>', true);
     host.onclick = function (e) {
-      if (e.target.closest("[data-dealgo]")) { petSlot = e.target.closest("[data-dealgo]").getAttribute("data-dealgo"); closeDealModal(); showTab("pet"); renderPet(); return; }
+      if (e.target.closest("[data-imbuy]")) { var r = itemModalRef; closeDealModal(); buyItem(r.childKey, r.slot, r.id); return; }
       if (e.target.closest("[data-dmclose]")) closeDealModal();
     };
+  }
+  function buyItem(childKey, slot, id) {
+    var it = findItem(slot, id); if (!it) return;
+    var pct = discountFor(childKey, slot, id), base = itemPrice(it), price = pct ? dealPrice(base, pct) : base, bal = balanceOf(childKey);
+    if (bal < price) { alert("3C 不夠喔！還差 " + fmtMin(price - bal) + "。"); return; }
+    state.usages.push({ id: uid(), child: childKey, date: todayStr(), minutes: price, note: "🛍️ 換購 " + it.name + (pct ? "（限時-" + pct + "%）" : "") });
+    if (!state.inventory[childKey]) state.inventory[childKey] = {};
+    state.inventory[childKey][it.id] = true;
+    afterPurchase(childKey);
+    chooseItem(childKey, slot, id);     // 已擁有 → 直接穿上＋存檔＋重畫
   }
   function showFlashPopup(f) {
     if (!f || !f.items.length) return;
@@ -1728,24 +1779,19 @@
   function afterPurchase(childKey) { var f = triggerFlash(childKey); if (f) showFlashPopup(f); }
   function dealsTick() {
     var now = Date.now();
-    if (deals.nextSaleAt && now >= deals.nextSaleAt) { rollSale(); if (petTabVisible()) renderPet(); showSalePopup(deals.sale); markSaleSeen(); }
-    var expired = false;
-    document.querySelectorAll("[data-countdown]").forEach(function (el) {
-      var end = +el.getAttribute("data-countdown");
-      if (end <= now) expired = true; else el.textContent = fmtCountdown(end - now);
-    });
-    if (expired && petTabVisible()) renderPet();
+    document.querySelectorAll("[data-countdown]").forEach(function (el) { el.textContent = fmtCountdown(Math.max(0, (+el.getAttribute("data-countdown")) - now)); });
+    var s = saleActive(), cyc = s ? s.cycle : -1;
+    if (cyc !== lastSaleCycle) { lastSaleCycle = cyc; if (petTabVisible()) renderPet(); }   // 換下一檔 → 重畫徽章
+    var modal = document.getElementById("dealmodal");
+    if (modal && modal.style.display === "block") { var cd = modal.querySelector("[data-countdown]"); if (cd && +cd.getAttribute("data-countdown") <= now) closeDealModal(); }
     var fEl = document.getElementById("flashCountdown");
     if (fEl) { var fend = +fEl.getAttribute("data-end"); if (fend <= now) closeDealModal(); else fEl.textContent = fmtCountdown(fend - now); }
   }
   function initDeals() {
-    if (!deals.nextSaleAt || deals.nextSaleAt <= Date.now()) rollSale();
-    if (saleActive() && deals.sale && !deals.sale.seen) { showSalePopup(deals.sale); markSaleSeen(); }
+    var s = saleActive(); lastSaleCycle = s ? s.cycle : -1;
     if (dealTimer) clearInterval(dealTimer);
     dealTimer = setInterval(dealsTick, 1000);
-    window.addEventListener("focus", function () {
-      if (deals.nextSaleAt && Date.now() >= deals.nextSaleAt) { rollSale(); if (petTabVisible()) renderPet(); showSalePopup(deals.sale); markSaleSeen(); }
-    });
+    window.addEventListener("focus", function () { var s2 = saleActive(), c2 = s2 ? s2.cycle : -1; if (c2 !== lastSaleCycle) { lastSaleCycle = c2; if (petTabVisible()) renderPet(); } });
   }
 
   // ---------- pet care ----------
@@ -2130,7 +2176,7 @@
   function render() { renderRules(); renderMonth(); renderCards(); renderPending(); renderRecords(); renderUsages(); if (isWide()) renderPet(); }
 
   // ================= render: 寵物 =================
-  var petWho = "mia", petSlot = "species", petPreview = null;
+  var petWho = "mia", petSlot = "species";
   function needsHTML(p) {
     return '<div class="stats">' + NEEDS.map(function (n) {
       var v = Math.round(p.needs[n.key] == null ? 80 : p.needs[n.key]); var lv = needTier(v);
@@ -2166,8 +2212,7 @@
     if (!none && !owned) tag = priceTagHTML(childKey, slotKey, it);
     else if (!none && it.limited) tag = '<span class="price lim">限定</span>';
     var icon = none ? '<span class="wemoji">🚫</span>' : '<span class="wpv">' + itemPreviewSVG(childKey, slotKey, it.id) + '</span>';
-    var pv = !none && petPreview && petPreview.slot === slotKey && petPreview.id === it.id;
-    return '<button class="witem' + (sel ? " sel" : "") + (pv ? " pv" : "") + (owned ? "" : " locked") + '" data-wslot="' + slotKey + '" data-witem="' + (none ? "" : it.id) + '">' +
+    return '<button class="witem' + (sel ? " sel" : "") + (owned ? "" : " locked") + '" data-wslot="' + slotKey + '" data-witem="' + (none ? "" : it.id) + '">' +
       icon + '<span class="wname">' + it.name + "</span>" + tag + "</button>";
   }
   function speciesWardrobe(childKey) {
@@ -2176,8 +2221,7 @@
       var inRoster = !!(cp.roster && cp.roster[it.id]), sel = cp.active === it.id, owned = inRoster || isOwned(childKey, it);
       var tag = (!inRoster && !owned) ? priceTagHTML(childKey, "species", it) : (it.limited ? '<span class="price lim">限定</span>' : "");
       var sub = inRoster ? (STAGE_NAME[petStage(cp.roster[it.id].growth)] + (cp.roster[it.id].name ? " · " + escapeHtml(cp.roster[it.id].name) : "")) : "未領養";
-      var pv = petPreview && petPreview.slot === "species" && petPreview.id === it.id;
-      out += '<button class="witem petcard' + (sel ? " sel" : "") + (pv ? " pv" : "") + (inRoster || owned ? "" : " locked") + '" data-wslot="species" data-witem="' + it.id + '">' +
+      out += '<button class="witem petcard' + (sel ? " sel" : "") + (inRoster || owned ? "" : " locked") + '" data-wslot="species" data-witem="' + it.id + '">' +
         petSVG(childKey, { species: it.id, pet: (cp.roster && cp.roster[it.id]) || defaultPet(), size: 50, showBg: false, mood: false }) +
         '<span class="wname">' + it.name + '</span><span class="wsub">' + sub + "</span>" + tag + "</button>";
     });
@@ -2227,13 +2271,6 @@
     if (lc) petWho = lc;
     else if (activeChildren().indexOf(petWho) < 0) petWho = activeChildren()[0];
     var ch = childOf(petWho), p = activePet(petWho), bal = balanceOf(petWho);
-    var rp = p, rpSpecies = state.pets[petWho].active;   // 試穿預覽：只改外觀、不動存檔
-    if (petPreview) {
-      rp = previewClone(p);
-      if (petPreview.slot === "species") rpSpecies = petPreview.id;
-      else if (petPreview.slot === "color") rp.color = petPreview.id;
-      else rp.wear[petPreview.slot] = petPreview.id;
-    }
     if (maybeDailyStory(p)) save();
     var nm = p.name || (ch.name + "的" + speciesName(state.pets[petWho].active));
     var walletStr = petWho === "self" ? "♾️ 無限" : fmtMin(bal);
@@ -2249,12 +2286,12 @@
     $("view-pet").innerHTML =
       swRow +
       '<div class="petstage ' + ch.cls + '">' +
-        '<div class="scenebg">' + sceneRoomSVG(rp) + "</div>" +
+        '<div class="scenebg">' + sceneRoomSVG(p) + "</div>" +
         '<div class="scene-hud">' + levelBadge(p) + coinPill(petWho, bal) + "</div>" +
         dealStageBadgeHTML(petWho) +
         (petFlash ? '<div class="scene-flash ' + petFlash.cls + '">' + petFlash.text + "</div>" : "") +
         bubble +
-        '<div class="petfloor"><div class="petart' + artCls + (petPreview ? " previewing" : "") + '">' + petSVG(petWho, { pet: rp, species: rpSpecies, size: 220, expr: petExpr, showBg: false }) + "</div></div>" +
+        '<div class="petfloor"><div class="petart' + artCls + '">' + petSVG(petWho, { size: 220, expr: petExpr, showBg: false }) + "</div></div>" +
         careRound(p) +
       "</div>" +
       '<section class="block petbox ' + ch.cls + '">' +
@@ -2265,8 +2302,7 @@
       "</section>" +
       '<section class="block"><div class="wallet ' + (bal < 0 ? "neg" : "") + '">👛 ' + ch.name + " 的 3C 存摺：<b>" + walletStr + "</b></div>" +
         '<h2 style="margin-top:12px">🛍️ 換裝小舖</h2>' + slotTabs + wardrobeHTML(petWho, petSlot) +
-        '<p class="hint">點還沒擁有的款式可以先<b>試穿預覽</b>看樣子，喜歡再按「購買」。到「🐾夥伴」可以領養新朋友（每一隻都要從小養大、分開計算）；🔒限定款要連續睡飽才解鎖，或用 3C 換。</p></section>' +
-      previewBarHTML(petWho);
+        '<p class="hint">點還沒擁有的款式會跳出<b>試穿彈窗</b>，先穿上看樣子、喜歡再買。到「🐾夥伴」可以領養新朋友（每一隻都要從小養大、分開計算）；🔒限定款要連續睡飽才解鎖，或用 3C 換。</p></section>';
     liveSig = petLiveSig(p);
   }
   // 寵物會「自己」隨時間變化：每隔一段時間就讓需求下降，狀態有變才重畫畫面
@@ -2308,42 +2344,19 @@
     afterPurchase(childKey);
     return true;
   }
-  // 預覽模式：未購買的款式先「暫時穿上」看樣子，不動到存檔；按「購買」才真的買。
+  // 把一隻寵物淺拷貝一份（含 wear），給「試穿彈窗」渲染預覽用，不動到存檔
   function previewClone(p) {
     var c = {}; for (var k in p) c[k] = p[k];
     c.wear = {}; var w = p.wear || {}; for (var s in w) c.wear[s] = w[s];
     return c;
   }
-  function previewBarHTML(childKey) {
-    if (!petPreview) return "";
-    var it = findItem(petPreview.slot, petPreview.id); if (!it) return "";
-    var pct = discountFor(childKey, petPreview.slot, petPreview.id), base = itemPrice(it), price = pct ? dealPrice(base, pct) : base;
-    var priceStr = pct ? ("<s>" + fmtMin(base) + "</s> " + fmtMin(price)) : fmtMin(price);
-    return '<div id="previewBar">' +
-      '<span class="pv-ic">' + dealItemPreview(childKey, petPreview.slot, petPreview.id) + "</span>" +
-      '<span class="pv-txt">👀 試穿中<b>' + escapeHtml(it.name) + "</b></span>" +
-      '<button class="pv-cancel" data-pvcancel="1" aria-label="取消試穿">✕</button>' +
-      '<button class="pv-buy" data-pvbuy="1">購買 ' + priceStr + " 3C" + (pct ? ' <i class="pv-off">-' + pct + "%</i>" : "") + "</button>" +
-      "</div>";
-  }
-  function buyPreview() {
-    if (!petPreview) return;
-    var slot = petPreview.slot, id = petPreview.id, it = findItem(slot, id); if (!it) return;
-    if (!tryBuy(petWho, slot, it)) return;     // 確認＋扣 3C；取消或不夠就維持試穿
-    petPreview = null;
-    chooseItem(petWho, slot, id);              // 已擁有 → 直接穿上＋存檔＋重畫
-  }
   function chooseItem(childKey, slotKey, itemId) {
     var cp = state.pets[childKey];
-    // 點「還沒擁有的付費款」→ 先試穿預覽（再點同一件＝取消）；按購買鈕才真的買
+    // 點「還沒擁有的款式」→ 開試穿彈窗（手遊風），喜歡再買
     if (itemId !== "") {
       var pit = findItem(slotKey, itemId);
-      if (pit && !isOwned(childKey, pit)) {
-        petPreview = (petPreview && petPreview.slot === slotKey && petPreview.id === itemId) ? null : { slot: slotKey, id: itemId };
-        renderPet(); return;
-      }
+      if (pit && !isOwned(childKey, pit)) { openItemModal(childKey, slotKey, itemId); return; }
     }
-    petPreview = null;
     if (slotKey === "species") {
       if (!cp.roster[itemId]) {
         var sit = findItem("species", itemId); if (!sit) return;
@@ -2371,20 +2384,17 @@
   $("view-pet").addEventListener("click", function (e) {
     var t;
     if ((t = e.target.closest("[data-act]"))) { doAction(petWho, t.getAttribute("data-act")); return; }
-    if (e.target.closest("[data-pvbuy]")) { buyPreview(); return; }
-    if (e.target.closest("[data-pvcancel]")) { petPreview = null; renderPet(); return; }
     if (sceneRunning) return;   // 互動播放中，先別切換
     if ((t = e.target.closest(".petart"))) { petTap(); return; }   // 點兔兔本人 → 開心反應
-    if ((t = e.target.closest("[data-petwho]"))) { petWho = t.getAttribute("data-petwho"); petExpr = "auto"; petPreview = null; clearTimeout(exprTimer); renderPet(); return; }
+    if ((t = e.target.closest("[data-petwho]"))) { petWho = t.getAttribute("data-petwho"); petExpr = "auto"; clearTimeout(exprTimer); renderPet(); return; }
     if ((t = e.target.closest("[data-rename]"))) { renamePet(); return; }
-    if ((t = e.target.closest("[data-dealslot]"))) { petSlot = t.getAttribute("data-dealslot"); renderPet(); var w = $("view-pet").querySelector(".wardrobe"); if (w && w.scrollIntoView) w.scrollIntoView({ behavior: "smooth", block: "center" }); return; }
+    if (e.target.closest("[data-saleopen]")) { var s = saleActive(); if (s) openItemModal(petWho, s.slot, s.id); return; }
     if ((t = e.target.closest("[data-slottab]"))) { petSlot = t.getAttribute("data-slottab"); renderPet(); return; }
     if ((t = e.target.closest("[data-witem]"))) { chooseItem(petWho, t.getAttribute("data-wslot"), t.getAttribute("data-witem")); return; }
   });
 
   // ---------- tabs ----------
   function showTab(t) {
-    petPreview = null;
     $("view-sleep").style.display = t === "sleep" ? "block" : "none";
     $("view-pet").style.display = t === "pet" ? "block" : "none";
     var tabs = document.querySelectorAll(".tab");


### PR DESCRIPTION
## 1) 限時特價：全裝置一致（修 bug）

原本是「每台裝置各自隨機 roll 一檔存本機」，所以每次登入／換裝置都不一樣。改成**完全用時間推導**（固定亂數種子）：

- 每台裝置、每次開 app 算出來**都一模一樣**。
- **常態**一檔接一檔不間斷，每檔 **3～5 天**；**倒數歸零才換**下一檔，單檔期間商品固定不變。
- 已用 node 驗證：同一檔內（+3h、+23h）商品完全相同；檔長都落在 3–5 天；換檔才換商品。

## 2) 試穿改成「手遊風彈窗」

移除舊的「角色身上試穿＋底部購買列」，改成置中的**商品試穿彈窗**：

- 角色站在**聚光台**上浮動展示（穿著目前造型＋這件新商品）。
- 商品名＋**稀有度**（限定款金色徽章＋背景閃粉動畫）。
- **原價劃線 → 折後價**＋折扣 %、特價倒數、該小孩的 3C 存摺餘額。
- **購買**鍵（3C 不夠時禁用並提示差多少）、「先逛逛」關閉。
- 點未擁有款式、或點角落特價徽章 → 開此彈窗；購買後直接穿上。

`node` 語法檢查通過、死碼已清、div 平衡（127/127）。版本 → v3.1。

> 註：彈窗外觀我在這環境無法用真機瀏覽器實測，麻煩上線後幫忙看一下質感。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014mmGf8aQEEFGUfhqz82X6k)_